### PR TITLE
XW-2831 | Disable matchOrigin

### DIFF
--- a/server/app/routes.js
+++ b/server/app/routes.js
@@ -57,7 +57,10 @@ let routes,
 			handler: assetsHandler,
 			config: {
 				cors: {
-					origin: ['*']
+					origin: ['*'],
+					// We can't set `access-control-allow-origin: 'http://gta.wikia.com'`
+					// The same URL is shared between wikis and cached in the browser
+					matchOrigin: false
 				}
 			}
 		},


### PR DESCRIPTION
## Description

Fix error caused by caching assets in the browser with CORS set for another wiki:
```
Access to CSS stylesheet at 'http://mobile-wiki.nocookie.net/mobile-wiki/main/assets/app-5ee89147c6670a8d64afc0dfc0b3fae3.css' from origin 'http://fallout.wikia.com' has been blocked by CORS policy: The 'Access-Control-Allow-Origin' header has a value 'http://serowiec.wikia.com' that is not equal to the supplied origin. Origin 'http://fallout.wikia.com' is therefore not allowed access.
```

## Reviewers

@kvas-damian