### PR TITLE
Update download translations task, extend Dockerfile by installing i18n-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ RUN echo '{ "allow_root": true }' > /root/.bowerrc
 # create release user so that we can chown output dir
 RUN useradd -u 663 release
 
+# install i18n-tools
+RUN apt-get update && apt-get install -y python python-pip
+RUN pip install pyparsing && pip install -i https://pypi.wikia-services.com/simple/ wikia.crowdin
+
 # prepare build dir
 RUN mkdir -p /build
 COPY package.json /build

--- a/tasks/download-translations.sh
+++ b/tasks/download-translations.sh
@@ -1,3 +1,5 @@
-for config_file in $(find ../crowdin/ -name '*.conf'); do
-     crowdin --project-config $config_file download-branch -b $1
+for config_file in $(find . -name '*.conf'); do
+     crowdin --global-config $1 --project-config $config_file download-branch -b $2
 done
+# Return true to do not break whole flow if there are no translations
+true


### PR DESCRIPTION
Mirrored PR from Mercury repository: https://github.com/Wikia/mercury/pull/3125

## Links

* http://wikia-inc.atlassian.net/browse/SER-852
* https://github.com/Wikia/deploytools-plugins/pull/186 - deploytools-plugins part
* https://github.com/Wikia/mercury/pull/3125 - mercury part

## Description

* Update Dockerfile to install i18n-tools (crowdin) to download translations during building Mercury application
* Update shell script for downloading translations to not break if there are no translations available
* Update shell script for downloading translations to pass also a global config file for i18n-tools

## Reviewers

@Wikia/services-team 
