### PR TITLE
(PLATFORM-2786) Bump vignette-js version

### DIFF
--- a/front/main/bower.json
+++ b/front/main/bower.json
@@ -14,7 +14,7 @@
     "qunit": "1.20.0",
     "sinonjs": "1.17.1",
     "script.js": "2.5.7",
-    "vignette": "wikia/vignette-js#2.5.0",
+    "vignette": "wikia/vignette-js#2.6.0",
     "visit-source": "Wikia/visit-source#0.1.1",
     "weppy": "Wikia/weppy#0.9.3",
     "wikia-style-guide": "Wikia/style-guide#v1.9.0"

--- a/server/npm-shrinkwrap.json
+++ b/server/npm-shrinkwrap.json
@@ -670,9 +670,9 @@
       "version": "1.3.6"
     },
     "vignette": {
-      "version": "2.5.0",
-      "from": "git://github.com/wikia/vignette-js.git#1b14c518837fafd3794bc969e77fea76e58a685a",
-      "resolved": "git://github.com/wikia/vignette-js.git#1b14c518837fafd3794bc969e77fea76e58a685a"
+      "version": "2.6.0",
+      "from": "git://github.com/wikia/vignette-js.git#eee2ca0a1ca72303837aaaf0cc049610b69e33cf",
+      "resolved": "git://github.com/wikia/vignette-js.git#eee2ca0a1ca72303837aaaf0cc049610b69e33cf"
     },
     "vision": {
       "version": "3.0.0"

--- a/server/package.json
+++ b/server/package.json
@@ -29,7 +29,7 @@
     "node-esapi": "0.0.1",
     "node-uuid": "1.4.7",
     "numeral": "2.0.4",
-    "vignette": "wikia/vignette-js#2.5.0",
+    "vignette": "wikia/vignette-js#2.6.0",
     "vision": "3.0.0",
     "wreck": "6.3.0"
   }


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/PLATFORM-2786

## Description

Bump vignette-js version to generate HTTPS vignette URLs.

## Reviewers

/cc @Wikia/core-platform-team 