### PR TITLE
XW-3224 | Encode the main page title before redirecting to it

### DIFF
--- a/app/routes/main-page-redirect.js
+++ b/app/routes/main-page-redirect.js
@@ -13,7 +13,7 @@ export default Route.extend(
 					'location',
 					this.get('wikiVariables.basePath') +
 					this.get('wikiVariables.articlePath') +
-					this.get('wikiVariables.mainPageTitle')
+					encodeURIComponent(this.get('wikiVariables.mainPageTitle'))
 				);
 			} else {
 				this.replaceWith('wiki-page', this.get('wikiVariables.mainPageTitle'));


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/XW-3224

## Description

`Location: "http://ja.lego.igor.wikia-dev.pl/wiki/ブリッキペディア、レゴ Wiki"` isn't a valid header, the title has to be encoded. I used `encodeURIComponent` on the title instead `encodeURI` on the whole URL because only the former one encodes characters like `;:@$!*(),/` which are valid for Mediawiki page title.

## Reviewers

@kvas-damian 