### PR TITLE
XW-2700 | stop using nocookie.net for the period of rollout

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -57,7 +57,8 @@ module.exports = function (defaults) {
 		fingerprint: {
 			extensions: ['js', 'css', 'svg', 'png', 'jpg', 'gif', 'map'],
 			replaceExtensions: ['html', 'css', 'js', 'hbs'],
-			prepend: 'http://mobile-wiki.nocookie.net/mobile-wiki/'
+			// TODO XW-3230 after rolling out fastboot to 100% of traffic, uncomment this
+			// prepend: 'http://mobile-wiki.nocookie.net/mobile-wiki/'
 		},
 		inlineContent: {
 			globals: `${inlineScriptsPath}globals.js`,


### PR DESCRIPTION
## Description

There is no easy way to share `mobile-wiki.nocookie.net` between two apps. Let's disable it for now and reenable after serving 100% of traffic from FastBoot.

## Reviewers

@kvas-damian 
