### PR TITLE
XW-2700 | Add respone body to non-json logs

### DIFF
--- a/app/utils/wiki-handlers/wiki-page.js
+++ b/app/utils/wiki-handlers/wiki-page.js
@@ -119,6 +119,13 @@ export default function getPageModel(params, fastboot, contentNamespaces) {
 							requestUrl: url,
 							responseUrl: response.url
 						});
+					}).catch((error) => {
+						throw new WikiPageFetchError({
+							code: 503
+						}).withAdditionalData({
+							requestUrl: url,
+							responseUrl: response.url
+						}).withPreviousError(error);
 					});
 				}
 			})


### PR DESCRIPTION
## Description

If we get an error and non-JSON response, log the response body. Don't fail if there is no response body.

## Reviewers

@kvas-damian 
