### PR TITLE
XW-2700 | Remove common.svg

### DIFF
--- a/app/inline-scripts/load-svg.js
+++ b/app/inline-scripts/load-svg.js
@@ -26,8 +26,6 @@
 		ajax.send();
 	}
 
-	// TODO check if fingerprint works correctly
 	loadDOMResource('/mobile-wiki/assets/main.svg');
-	loadDOMResource('/mobile-wiki/assets/common.svg');
 	loadDOMResource('/mobile-wiki/assets/design-system.svg');
 })();

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -94,12 +94,6 @@ module.exports = function (defaults) {
 					sourceDirs: 'app/symbols/main',
 					outputFile: '/assets/main.svg'
 				},
-				// This duplicates build-common-symbols task but we still want to do it
-				// as there is no easy way to use external rev-manifest.json in here
-				{
-					sourceDirs: '../common/public/symbols',
-					outputFile: '/assets/common.svg'
-				}
 			]
 		}
 	});


### PR DESCRIPTION
## Description

After separating mercury and mobile-wiki we have empty `common.svg` so there is no need to include it.

## Reviewers

@rogatty 
