### PR TITLE
Serialize error data sent to Elasticsearch

### DIFF
--- a/app/services/fastboot-error-consumer.js
+++ b/app/services/fastboot-error-consumer.js
@@ -13,7 +13,7 @@ const {inject} = Ember;
  * @returns {Object}
  */
 const additionalDataSerializer = (additionalData) => {
-	if (Array.isArray(additionalData)) {
+	if (additionalData && Array.isArray(additionalData)) {
 		return Object.assign({}, additionalData);
 	}
 
@@ -28,9 +28,9 @@ const additionalDataSerializer = (additionalData) => {
  * @returns {Object}
  */
 const previousErrorSerializer = (previousError) => {
-	if (previousError.additionalData && Array.isArray(previousError.additionalData)) {
+	if (previousError && previousError.additionalData) {
 		const serialized = Object.assign({}, previousError);
-		serialized.additionalData = Object.assign({}, previousError.additionalData);
+		serialized.additionalData = additionalDataSerializer(previousError.additionalData);
 		return serialized;
 	}
 


### PR DESCRIPTION
## Links

* https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html

## Description

Elasticsearch doesn't play well with arrays of objects, they can't be indexed, searched nor filtered. Let's log:
```
{ '0': {
    host: 'muppet.igor.wikia-dev.pl',
    url: 'http://muppet.igor.wikia-dev.pl/wikia.php?controller=MercuryApi&method=getWikiVariables&format=json'
} }
```
Instead of:
```
[ {
    host: 'muppet.igor.wikia-dev.pl',
    url: 'http://muppet.igor.wikia-dev.pl/wikia.php?controller=MercuryApi&method=getWikiVariables&format=json'
} ]
```

## Reviewers

@kvas-damian 