### PR TITLE
XW-3270 | Fix GA tracking 2nd pageview

### DIFF
--- a/app/routes/wiki-page.js
+++ b/app/routes/wiki-page.js
@@ -133,6 +133,10 @@ export default Route.extend(
 
 				if (handler) {
 					transition.then(() => {
+						// Tracking has to happen after transition is done. Otherwise we track to fast and url isn't
+						// updated yet. `didTrasition` hook is called too fast.
+						this.trackPageView(model);
+
 						if (typeof handler.afterTransition === 'function') {
 							handler.afterTransition(model, this.get('wikiVariables.id'), this.get('wikiVariables.host'));
 						}
@@ -251,8 +255,6 @@ export default Route.extend(
 			 * @returns {boolean}
 			 */
 			didTransition() {
-				this.trackPageView(this.modelFor(this.routeName));
-
 				if (this.get('redirectEmptyTarget')) {
 					this.controllerFor('application').addAlert({
 						message: this.get('i18n').t('article.redirect-empty-target'),


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/XW-3270

## Description

In https://github.com/Wikia/mobile-wiki/pull/49 we introduced a bug - tracking 2nd and later pageviews were sent too fast and tracked previous page. After cleanup in https://github.com/Wikia/mobile-wiki/pull/72/files#diff-bc854854b6ca39b623c19e1c8c38d076R6 we can move tracking back to it's original place.

## Reviewers

@rogatty 
