### PR TITLE
XW-3107 | Bump mercury-shared

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "form-data": "2.1.2",
     "i18next": "7.1.2",
     "loader.js": "4.2.2",
-    "mercury-shared": "github:wikia/mercury-shared#1.0.3",
+    "mercury-shared": "github:wikia/mercury-shared#1.0.4",
     "moment": "2.11.2",
     "moment-timezone": "0.5.0",
     "numeral": "2.0.6",


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/XW-3107

## Description

Currently we use different `beacon` on Oasis and Mercury. This PR unifies it and both platforms use `beacon` from the same source. The same `beacon` on Oasis and Mercury means that we can correctly track user session when visiting both platforms.

## Reviewers

@Wikia/x-wing 

https://github.com/Wikia/mercury-shared/pull/2