### PR TITLE
XW-3206 | Correct response status codes in Express

### DIFF
--- a/server/app/server.js
+++ b/server/app/server.js
@@ -55,7 +55,7 @@ const server = new FastBootAppServer({
 		app.use((err, req, res, next) => {
 			if (err) {
 				// Handle errors that don't go to FastBoot, like Bad Request etc.
-				const statusCode = Math.max(res.statusCode, err.statusCode);
+				const statusCode = Math.max(res.statusCode, err.statusCode || 500);
 				const level = levelFn(statusCode);
 				const logFn = req.log[level].bind(req.log);
 


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/XW-3206

## Description

Previously we were using incorrect statusCode that we finally served to client. In this PR on error we get highest statusCode and serve it to browser.

## Reviewers

@rogatty 
