### PR TITLE
XW-3241 | Don't redirect client when api returns 200 without redirect

### DIFF
--- a/app/models/wiki-variables.js
+++ b/app/models/wiki-variables.js
@@ -35,9 +35,21 @@ WikiVariablesModel.reopenClass({
 
 				if (contentType && contentType.indexOf('application/json') !== -1) {
 					return response.json();
-				} else {
+				} else if (url !== response.url) {
+					// API was redirected to non-json page
 					throw new NonJsonApiResponseError().withAdditionalData({
 						redirectLocation: response.url
+					});
+				} else {
+					// non-json API response
+					return response.text().then((responseBody) => {
+						throw new WikiVariablesFetchError({
+							code: response.status || 503
+						}).withAdditionalData({
+							host,
+							responseBody,
+							url
+						});
 					});
 				}
 

--- a/app/models/wiki-variables.js
+++ b/app/models/wiki-variables.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import fetch from '../utils/mediawiki-fetch';
 import {buildUrl} from '../utils/url';
-import {NonJsonApiResponseError, WikiVariablesFetchError} from '../utils/errors';
+import {WikiVariablesRedirectError, WikiVariablesFetchError} from '../utils/errors';
 
 const WikiVariablesModel = Ember.Object.extend({});
 
@@ -37,7 +37,7 @@ WikiVariablesModel.reopenClass({
 					return response.json();
 				} else if (url !== response.url) {
 					// API was redirected to non-json page
-					throw new NonJsonApiResponseError().withAdditionalData({
+					throw new WikiVariablesRedirectError().withAdditionalData({
 						redirectLocation: response.url
 					});
 				} else {
@@ -63,7 +63,7 @@ WikiVariablesModel.reopenClass({
 				return response.data;
 			})
 			.catch((error) => {
-				if (error.name === 'NonJsonApiResponseError') {
+				if (error.name === 'WikiVariablesRedirectError') {
 					throw error;
 				}
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -4,7 +4,7 @@ import ApplicationModel from '../models/application';
 import HeadTagsStaticMixin from '../mixins/head-tags-static';
 import getLinkInfo from '../utils/article-link';
 import ErrorDescriptor from '../utils/error-descriptor';
-import {NonJsonApiResponseError, DontLogMeError} from '../utils/errors';
+import {WikiVariablesRedirectError, DontLogMeError} from '../utils/errors';
 import {disableCache, setResponseCaching, CachingInterval, CachingPolicy} from '../utils/fastboot-caching';
 import {normalizeToUnderscore} from '../utils/string';
 import {track, trackActions} from '../utils/track';
@@ -64,7 +64,7 @@ export default Route.extend(
 					return applicationData;
 				})
 				.catch((error) => {
-					if (error instanceof NonJsonApiResponseError) {
+					if (error instanceof WikiVariablesRedirectError) {
 						fastboot.get('response.headers').set(
 							'location',
 							error.additionalData[0].redirectLocation

--- a/app/utils/errors.js
+++ b/app/utils/errors.js
@@ -10,8 +10,8 @@ const DontLogMeError = defineError({
 	message: `Hack: this error was created only to stop executing Ember and redirect immediately`
 });
 
-const NonJsonApiResponseError = defineError({
-	name: 'NonJsonApiResponseError',
+const WikiVariablesRedirectError = defineError({
+	name: 'WikiVariablesRedirectError',
 	message: `The API response was in incorrect format`,
 	extends: DontLogMeError
 });
@@ -55,7 +55,7 @@ export {
 	getFetchErrorMessage,
 	DesignSystemFetchError,
 	DontLogMeError,
-	NonJsonApiResponseError,
+	WikiVariablesRedirectError,
 	UserLoadDetailsFetchError,
 	UserLoadInfoFetchError,
 	TrackingDimensionsFetchError,


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/XW-3241

## Description

When API returned 200 with HTML response we're redirecting browser to API url. It's correct behavior only when API returns redirect and then we get HTML. In this case we should server error.

## Reviewers

@rogatty 
