### PR TITLE
XW-3223 | Display placeholder for hero image before Ember loads

### DIFF
--- a/app/components/article-media-thumbnail.js
+++ b/app/components/article-media-thumbnail.js
@@ -3,6 +3,7 @@ import InViewportMixin from 'ember-in-viewport';
 import ViewportMixin from '../mixins/viewport';
 import MediaThumbnailUtilsMixin from '../mixins/media-thumbnail-utils';
 import Thumbnailer from '../modules/thumbnailer';
+import {normalizeThumbWidth} from '../utils/thumbnail';
 
 export default Ember.Component.extend(
 	InViewportMixin,
@@ -69,7 +70,7 @@ export default Ember.Component.extend(
 				width = originalWidth;
 				height = originalHeight;
 			} else {
-				width = this.get('forcedWidth') || this.normalizeThumbWidth(this.get('viewportDimensions.width'));
+				width = this.get('forcedWidth') || normalizeThumbWidth(this.get('viewportDimensions.width'));
 				height = this.get('forcedHeight') ||
 					this.calculateHeightBasedOnWidth(originalWidth, originalHeight, width);
 			}

--- a/app/components/wikia-ui-components/wiki-page-header.js
+++ b/app/components/wikia-ui-components/wiki-page-header.js
@@ -24,6 +24,7 @@
 import Ember from 'ember';
 import Thumbnailer from '../../modules/thumbnailer';
 import ViewportMixin from '../../mixins/viewport';
+import {thumbSize} from '../../utils/thumbnail';
 import {track, trackActions} from '../../utils/track';
 
 const {
@@ -37,10 +38,11 @@ const {
 export default Component.extend(
 	ViewportMixin,
 	{
+		fastboot: inject.service(),
 		wikiVariables: inject.service(),
 		imageAspectRatio: 16 / 9,
 		classNames: ['wiki-page-header'],
-		classNameBindings: ['heroImage:has-hero-image'],
+		classNameBindings: ['heroImage:has-hero-image', 'fastboot.isFastBoot:is-fastboot'],
 		attributeBindings: ['style'],
 		isMainPage: false,
 		siteName: computed.reads('wikiVariables.siteName'),
@@ -51,10 +53,20 @@ export default Component.extend(
 				windowWidth = this.get('viewportDimensions.width'),
 				imageAspectRatio = this.get('imageAspectRatio');
 
-			let imageWidth, imageHeight, maxWidth, computedHeight, cropMode, thumbUrl;
+			let computedHeight,
+				cropMode,
+				imageHeight,
+				imageWidth,
+				maxWidth,
+				thumbUrl;
 
 			if (isEmpty(heroImage)) {
 				return '';
+			}
+
+			if (this.get('fastboot.isFastBoot')) {
+				// We display brackets placeholder as the background using .is-fastboot class
+				return new htmlSafe(`height: ${thumbSize.medium}px`);
 			}
 
 			imageWidth = heroImage.width || windowWidth;

--- a/app/mixins/media-thumbnail-utils.js
+++ b/app/mixins/media-thumbnail-utils.js
@@ -99,31 +99,5 @@ export default Ember.Mixin.create(
 				}
 			};
 		},
-
-		/**
-		 * Normalize image width used to generate a thumbnail
-		 * so we don't pollute the cache with multiple thumbs for every device width
-		 *
-		 * @param {number} width
-		 * @returns {number}
-		 */
-		normalizeThumbWidth(width) {
-			const thumbSize = {
-				small: 284,
-				medium: 340,
-				large: 732,
-				maximum: 985
-			};
-
-			if (width <= thumbSize.small) {
-				return thumbSize.small;
-			} else if (width <= thumbSize.medium) {
-				return thumbSize.medium;
-			} else if (width <= thumbSize.large) {
-				return thumbSize.large;
-			}
-
-			return thumbSize.maximum;
-		},
 	}
 );

--- a/app/styles/component/wikia-ui-components/_wiki-page-header.scss
+++ b/app/styles/component/wikia-ui-components/_wiki-page-header.scss
@@ -77,25 +77,14 @@
 	}
 }
 
+.wiki-page-header.has-hero-image.is-fastboot {
+	@extend %image-placeholder;
+	@include is-loading;
+}
+
 .wiki-page-header.has-hero-image .wiki-page-header__wrapper {
 	background: linear-gradient(to bottom, transparent 70%, rgba(0, 0, 0,.6) 100%);
 	height: 100%;
-}
-
-.wiki-page-header.has-hero-image-preload {
-	@include is-loading;
-
-	height: 0;
-	padding-bottom: 100%;
-	position: relative;
-	width: 100%;
-}
-
-.wiki-page-header.has-hero-image-preload .wiki-page-header__wrapper {
-	bottom: 0;
-	left: 0;
-	position: absolute;
-	right: 0;
 }
 
 .wiki-page-header__main {

--- a/app/utils/thumbnail.js
+++ b/app/utils/thumbnail.js
@@ -1,0 +1,25 @@
+export const thumbSize = {
+	small: 284,
+	medium: 340,
+	large: 732,
+	maximum: 985
+};
+
+/**
+ * Normalize image width used to generate a thumbnail
+ * so we don't pollute the cache with multiple thumbs for every device width
+ *
+ * @param {number} width
+ * @returns {number}
+ */
+export function normalizeThumbWidth(width) {
+	if (width <= thumbSize.small) {
+		return thumbSize.small;
+	} else if (width <= thumbSize.medium) {
+		return thumbSize.medium;
+	} else if (width <= thumbSize.large) {
+		return thumbSize.large;
+	}
+
+	return thumbSize.maximum;
+}


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/XW-3223

## Description

Hero image size and crop mode are based on the viewport width. We don't know it on the server side, so let's assume it's 340px (number based on GA stats and already used for normalizing) and display a placeholder 340x340.

## Reviewers

@Wikia/x-wing 