### PR TITLE
ADEN-5160 | Featured Video - disable ads on replay

### DIFF
--- a/app/modules/video-players/ooyala-v4.js
+++ b/app/modules/video-players/ooyala-v4.js
@@ -63,6 +63,7 @@ export default class OoyalaV4Player extends BasePlayer {
 						],
 						useGoogleCountdown: true
 					};
+					this.params.replayAds = false;
 				}
 
 				window.OO.Player.create(this.containerId, this.params.videoId, this.params);


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/ADEN-5160

## Description
There is a bug in html5-skin that doesn't hide end screen on video replay when we provide vastUrl that doesn't have any ads targeted. As a short term fix we decided to disable ads on replay.

## Reviewers

@Wikia/adeng 
