### PR TITLE
Add Video MOAT tracking label

### DIFF
--- a/app/modules/video-players/ooyala-google-ima-plugin.js
+++ b/app/modules/video-players/ooyala-google-ima-plugin.js
@@ -4275,7 +4275,7 @@ export default function loadOoyalaGoogleImaPlugin(isMoatTrackingForFeaturedVideo
 
                             // ----------------------------------------- MOAT - START----------------------------------
                             if (isMoatTrackingForFeaturedVideoEnabled) {
-                                moatVideoTracker(_IMAAdsManager, _uiContainer, google.ima.ViewMode.NORMAL, 'ooyala');
+                                moatVideoTracker(_IMAAdsManager, _uiContainer, google.ima.ViewMode.NORMAL, 'ooyala', 'featured-video');
                             }
                             // ----------------------------------------- MOAT - END -----------------------------------
 


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/ADEN-5427
* https://wikia-inc.atlassian.net/browse/ADEN-5269

## Description

In order to gather viewability data for featured video pre-rolls, we need MOAT video tracking enabled.
