### PR TITLE
XW-3608 | Set video-specific details as GA custom dimensions

### DIFF
--- a/app/components/article-featured-video.js
+++ b/app/components/article-featured-video.js
@@ -2,7 +2,6 @@ import Ads from '../modules/ads';
 import Ember from 'ember';
 import InViewportMixin from 'ember-in-viewport';
 import VideoLoader from '../modules/video-loader';
-import duration from '../helpers/duration';
 import {track, trackActions} from '../utils/track';
 import extend from '../utils/extend';
 
@@ -39,6 +38,7 @@ export default Component.extend(InViewportMixin,
 		// hook, however it is fired twice with new attributes.
 		videoIdObserver: on('didInsertElement', observer('model.embed.jsParams.videoId', function () {
 			this.destroyVideoPlayer();
+			this.updateCustomDimensions();
 			this.initVideoPlayer();
 		})),
 
@@ -90,15 +90,8 @@ export default Component.extend(InViewportMixin,
 		onCreate(player) {
 			this.player = player;
 
-			player.mb.subscribe(window.OO.EVENTS.PLAYBACK_READY, 'ui-title-update', () => {
-				const videoTitle = player.getTitle(),
-					videoTime = duration.compute([Math.floor(player.getDuration() / 1000)]);
-
-				this.setProperties({
-					videoTitle,
-					videoTime,
-					isPlayerLoading: false
-				});
+			player.mb.subscribe(window.OO.EVENTS.PLAYBACK_READY, 'featured-video', () => {
+				this.set('isPlayerLoading', false);
 			});
 
 			// when playing video on article with infobox, closing fullscreen also has to pause video
@@ -142,6 +135,17 @@ export default Component.extend(InViewportMixin,
 			}
 
 			videoLoader.loadPlayerClass();
+		},
+
+		/**
+		 * Set video-specific data as GA custom dimensions
+		 *
+		 * @returns {void}
+		 */
+		updateCustomDimensions() {
+			M.tracker.UniversalAnalytics.setDimension(34, this.get('model.embed.jsParams.videoId'));
+			M.tracker.UniversalAnalytics.setDimension(35, this.get('model.title'));
+			M.tracker.UniversalAnalytics.setDimension(36, this.get('model.labels'));
 		},
 
 		setupTracking(player) {

--- a/app/templates/components/article-featured-video.hbs
+++ b/app/templates/components/article-featured-video.hbs
@@ -8,9 +8,9 @@
 			<div class="article-featured-video__details">
 				<div class="article-featured-video__label">
 					Watch
-					<span class="article-featured-video__time">{{videoTime}}</span>
+					<span class="article-featured-video__time">{{model.duration}}</span>
 				</div>
-				<div class="article-featured-video__title">{{videoTitle}}</div>
+				<div class="article-featured-video__title">{{model.title}}</div>
 			</div>
 			<div class="article-featured-video__play-circle">
 				{{#if hasTinyPlayIcon}}

--- a/app/utils/track.js
+++ b/app/utils/track.js
@@ -175,7 +175,7 @@ export function trackPageView(isInitialPageView, uaDimensions) {
 	const enableTracking = !M.getFromShoebox('runtimeConfig.noExternals') && !M.getFromShoebox('serverError');
 
 	if (!isInitialPageView && enableTracking) {
-		// Defined in templates/components/fastboot-only/
+		// Defined in /app/inline-scripts/
 		window.trackQuantcastPageView();
 		window.trackComscorePageView();
 		window.trackNielsenPageView();
@@ -202,17 +202,6 @@ export function trackExperiment(experiment, params) {
 
 	params.label = [experiment, group, params.label].join('=');
 	track(params);
-}
-
-/**
- * Function to save data about registered users that seen the
- * New Contributor Flow modal
- *
- * @param {TrackingParams} params
- * @returns {void}
- */
-export function trackRegister(params) {
-	M.tracker.Internal.track('special/newcontributorflow', params);
 }
 
 /**


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/XW-3608
* https://github.com/Wikia/app/pull/13182

## Description

Send video ID, title and Oooyala labels to GA as custom dimensions.
Use title and duration coming from API instead of waiting for Ooyala event.

## Reviewers

@Wikia/x-wing 