### PR TITLE
AMP-4: emit amphtml header

### DIFF
--- a/app/mixins/head-tags-dynamic.js
+++ b/app/mixins/head-tags-dynamic.js
@@ -40,7 +40,8 @@ export default Ember.Mixin.create({
 				keywords: `${this.get('wikiVariables.siteMessage')}` +
 				`,${this.get('wikiVariables.siteName')}` +
 				`,${this.get('wikiVariables.dbName')}`,
-				appleItunesApp: ''
+				appleItunesApp: '',
+				amphtml: data.amphtml
 			};
 
 		if (data.htmlTitle) {

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -26,6 +26,10 @@
 	<link rel="apple-touch-icon" href="{{model.appleTouchIcon.url}}" sizes="{{model.appleTouchIcon.size}}" />
 {{/if}}
 
+{{#if model.amphtml}}
+	<link rel="amphtml" href="{{model.amphtml}}" />
+{{/if}}
+
 {{! Tags updated on each transition (dynamic head tags) }}
 {{#if model.htmlTitle}}
 	<title>{{model.htmlTitle}}</title>


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/AMP-4
* https://www.ampproject.org/docs/guides/discovery
* https://github.com/Wikia/app/pull/13620

## Description

If AMP experiment is enabled for a given article, `amphtml` property with AMP article address is returned by Mercury API. If this is not empty, emit the `amphtml` link in the page header so amp version of the page can be crawled and indexed.
