### PR TITLE
AMP-4: propagate amphtml property

### DIFF
--- a/app/models/wiki/article.js
+++ b/app/models/wiki/article.js
@@ -100,6 +100,7 @@ export default BaseModel.extend({
 			}
 
 			articleProperties.isMainPage = data.isMainPage || false;
+			articleProperties.amphtml = data.amphtml;
 
 			if (data.curatedMainPageData) {
 				articleProperties.curatedMainPageData = data.curatedMainPageData;

--- a/app/routes/wiki-page.js
+++ b/app/routes/wiki-page.js
@@ -183,7 +183,8 @@ export default Route.extend(
 					htmlTitle: model.get('htmlTitle'),
 					description: model.get('description'),
 					robots: 'index,follow',
-					canonical: pageFullUrl
+					canonical: pageFullUrl,
+					amphtml: model.get('amphtml')
 				};
 
 			if (pageUrl) {


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/AMP-4

## Description

`amphtml` property was not propagated to the article model and wasn't visible when rendering page header.

