### PR TITLE
XW-3981 | prevent duplicated LyricFind calls

### DIFF
--- a/app/routes/wiki-page.js
+++ b/app/routes/wiki-page.js
@@ -138,13 +138,13 @@ export default Route.extend(
 						this.trackPageView(model);
 
 						if (typeof handler.afterTransition === 'function' && fastboot.get('isFastBoot')) {
-                            handler.afterTransition({
-                                model,
-                                request: fastboot.get("request"),
-                                wikiId: this.get('wikiVariables.id'),
-                                host: this.get('wikiVariables.host')
-                            });
-                        }
+							handler.afterTransition({
+								model,
+								request: fastboot.get("request"),
+								wikiId: this.get('wikiVariables.id'),
+								host: this.get('wikiVariables.host')
+							});
+						}
 					});
 
 					this.set('wikiHandler', handler);

--- a/app/routes/wiki-page.js
+++ b/app/routes/wiki-page.js
@@ -117,7 +117,7 @@ export default Route.extend(
 		},
 
 		/**
-		 * @param {Ember.Object} model
+		 * @param {Ember.model} model
 		 * @param {EmberStates.Transition} transition
 		 * @returns {void}
 		 */
@@ -134,12 +134,17 @@ export default Route.extend(
 						this.get('liftigniter').initLiftigniter(model.adsContext);
 
 						// Tracking has to happen after transition is done. Otherwise we track to fast and url isn't
-						// updated yet. `didTrasition` hook is called too fast.
+						// updated yet. `didTransition` hook is called too fast.
 						this.trackPageView(model);
 
-						if (typeof handler.afterTransition === 'function') {
-							handler.afterTransition(model, this.get('wikiVariables.id'), this.get('wikiVariables.host'));
-						}
+						if (typeof handler.afterTransition === 'function' && fastboot.get('isFastBoot')) {
+                            handler.afterTransition({
+                                model,
+                                request: fastboot.get("request"),
+                                wikiId: this.get('wikiVariables.id'),
+                                host: this.get('wikiVariables.host')
+                            });
+                        }
 					});
 
 					this.set('wikiHandler', handler);

--- a/app/routes/wiki-page.js
+++ b/app/routes/wiki-page.js
@@ -117,7 +117,7 @@ export default Route.extend(
 		},
 
 		/**
-		 * @param {Ember.model} model
+		 * @param {Ember.Object} model
 		 * @param {EmberStates.Transition} transition
 		 * @returns {void}
 		 */
@@ -140,8 +140,8 @@ export default Route.extend(
 						if (typeof handler.afterTransition === 'function' && fastboot.get('isFastBoot')) {
 							handler.afterTransition({
 								model,
-								logger: this.get("logger"),
-								headers: fastboot.get("request.headers"),
+								logger: this.get('logger'),
+								headers: fastboot.get('request.headers'),
 								wikiId: this.get('wikiVariables.id'),
 								host: this.get('wikiVariables.host')
 							});

--- a/app/routes/wiki-page.js
+++ b/app/routes/wiki-page.js
@@ -140,7 +140,8 @@ export default Route.extend(
 						if (typeof handler.afterTransition === 'function' && fastboot.get('isFastBoot')) {
 							handler.afterTransition({
 								model,
-								request: fastboot.get("request"),
+								logger: this.get("logger"),
+								headers: fastboot.get("request.headers"),
 								wikiId: this.get('wikiVariables.id'),
 								host: this.get('wikiVariables.host')
 							});

--- a/app/utils/wiki-handlers/article.js
+++ b/app/utils/wiki-handlers/article.js
@@ -57,10 +57,9 @@ function sendLyricsPageView({model, host, logger, headers}) {
 			gracenoteid: 0,
 			rand: (`${Math.random()}`).substr(2, 8)
 		}
-	}))
-		.then(() => {
-			logger.info("LyricFind PageView tracking event sent", { headers: headers.getAll() });
-		});
+	})).then(() => {
+		logger.info("LyricFind PageView tracking event sent", {headers: headers.getAll()});
+	});
 }
 
 /**

--- a/app/utils/wiki-handlers/article.js
+++ b/app/utils/wiki-handlers/article.js
@@ -18,7 +18,7 @@ function addOoyalaAssets(route) {
 
 /**
  * @param {Ember.Route} route
- * @param {Ember.model} model
+ * @param {Ember.Object} model
  * @returns {void}
  */
 function afterModel(route, model) {
@@ -40,7 +40,7 @@ function afterModel(route, model) {
  *
  * https://github.com/Wikia/app/blob/dev/extensions/3rdparty/LyricWiki/LyricFind/js/modules/LyricFind.Tracker.js
  *
- * @param {Ember.model} model
+ * @param {Ember.Object} model
  * @param {String} host
  * @param {Ember.Object} logger - logger service
  * @param {Ember.Object} headers - FastBoot request's headers
@@ -58,12 +58,12 @@ function sendLyricsPageView({model, host, logger, headers}) {
 			rand: (`${Math.random()}`).substr(2, 8)
 		}
 	})).then(() => {
-		logger.info("LyricFind PageView tracking event sent", {headers: headers.getAll()});
+		logger.info('LyricFind PageView tracking event sent', {headers: headers.getAll()});
 	});
 }
 
 /**
- * @param {Ember.model} model
+ * @param {Ember.Object} model
  * @param {number} wikiId
  * @param {Ember.Object} headers - FastBoot request's headers
  * @returns {boolean}
@@ -71,15 +71,17 @@ function sendLyricsPageView({model, host, logger, headers}) {
 function shouldSendLyricFindRequest({model, wikiId, headers}) {
 	const lyricWikiId = 43339;
 
+	// 'goreplay' header indicates http traffic replayed between SJC and RES
+	// for more info please read 'Confluence > Operations > Goreplay' article
 	return wikiId === lyricWikiId
-		&& !model.get("isMainPage")
-		&& headers.get("X-Wikia-Is-Internal-Request") !== "goreplay";
+		&& !model.get('isMainPage')
+		&& headers.get('X-Wikia-Is-Internal-Request') !== 'goreplay';
 }
 
 /**
  * Hook triggered on transition.then() in Route::afterModel()
  *
- * @param {Ember.model} model
+ * @param {Ember.Object} model
  * @param {number} wikiId
  * @param {String} host
  * @param {Ember.Object} logger - logger service

--- a/app/utils/wiki-handlers/article.js
+++ b/app/utils/wiki-handlers/article.js
@@ -42,8 +42,10 @@ function afterModel(route, model) {
  *
  * @param {Ember.model} model
  * @param {String} host
+ * @param {Ember.Object} logger - logger service
+ * @param {Ember.Object} headers - FastBoot request's headers
  */
-function sendLyricsPageView(model, host) {
+function sendLyricsPageView({model, host, logger, headers}) {
 	fetch(buildUrl({
 		host,
 		path: '/wikia.php',
@@ -55,18 +57,20 @@ function sendLyricsPageView(model, host) {
 			gracenoteid: 0,
 			rand: (`${Math.random()}`).substr(2, 8)
 		}
-	}));
+	}))
+		.then(() => {
+			logger.info("LyricFind PageView tracking event sent", { headers: headers.getAll() });
+		});
 }
 
 /**
  * @param {Ember.model} model
  * @param {number} wikiId
- * @param {Object} request - FastBoot request
+ * @param {Ember.Object} headers - FastBoot request's headers
  * @returns {boolean}
  */
-function shouldSendLyricFindRequest(model, wikiId, request) {
+function shouldSendLyricFindRequest({model, wikiId, headers}) {
 	const lyricWikiId = 43339;
-	const headers = request.get("headers");
 
 	return wikiId === lyricWikiId
 		&& !model.get("isMainPage")
@@ -79,11 +83,12 @@ function shouldSendLyricFindRequest(model, wikiId, request) {
  * @param {Ember.model} model
  * @param {number} wikiId
  * @param {String} host
- * @param {Object} request - FastBoot request
+ * @param {Ember.Object} logger - logger service
+ * @param {Ember.Object} headers - FastBoot request's headers
  */
-function afterTransition({model, wikiId, host, request}) {
-	if (shouldSendLyricFindRequest(model, wikiId, request)) {
-		sendLyricsPageView(model, host);
+function afterTransition({model, wikiId, host, headers, logger}) {
+	if (shouldSendLyricFindRequest({model, wikiId, headers})) {
+		sendLyricsPageView({model, host, headers, logger});
 	}
 }
 

--- a/app/utils/wiki-handlers/article.js
+++ b/app/utils/wiki-handlers/article.js
@@ -44,18 +44,18 @@ function afterModel(route, model) {
  * @param {String} host
  */
 function sendLyricsPageView(model, host) {
-    fetch(buildUrl({
+	fetch(buildUrl({
 		host,
-        path: '/wikia.php',
-        query: {
-            controller: 'LyricFind',
-            method: 'track',
-            title: model.get('title'),
-            amgid: 0,
-            gracenoteid: 0,
-            rand: (`${Math.random()}`).substr(2, 8)
-        }
-    }));
+		path: '/wikia.php',
+		query: {
+			controller: 'LyricFind',
+			method: 'track',
+			title: model.get('title'),
+			amgid: 0,
+			gracenoteid: 0,
+			rand: (`${Math.random()}`).substr(2, 8)
+		}
+	}));
 }
 
 /**
@@ -65,12 +65,12 @@ function sendLyricsPageView(model, host) {
  * @returns {boolean}
  */
 function shouldSendLyricFindRequest(model, wikiId, request) {
-    const lyricWikiId = 43339;
-    const headers = request.get("headers");
+	const lyricWikiId = 43339;
+	const headers = request.get("headers");
 
-    return wikiId === lyricWikiId
-        && !model.get("isMainPage")
-        && headers.get("X-Wikia-Is-Internal-Request") !== "goreplay";
+	return wikiId === lyricWikiId
+		&& !model.get("isMainPage")
+		&& headers.get("X-Wikia-Is-Internal-Request") !== "goreplay";
 }
 
 /**
@@ -81,10 +81,10 @@ function shouldSendLyricFindRequest(model, wikiId, request) {
  * @param {String} host
  * @param {Object} request - FastBoot request
  */
-function afterTransition({ model, wikiId, host, request }) {
-    if (shouldSendLyricFindRequest(model, wikiId, request)) {
-        sendLyricsPageView(model, host);
-    }
+function afterTransition({model, wikiId, host, request}) {
+	if (shouldSendLyricFindRequest(model, wikiId, request)) {
+		sendLyricsPageView(model, host);
+	}
 }
 
 /**


### PR DESCRIPTION
## Links

https://wikia-inc.atlassian.net/browse/XW-3981

## Description

LyricFind tracking requests are duplicated, so we're trying to prevent that

## Reviewers

@Wikia/x-wing 
@frankfarmer - Request will be sent only by our Fastboot service for server-side rendering, I've also added "post-sent"  log with all request headers included - will that suit your needs?
