### PR TITLE
Allow local development with use of proxy auto-config

### DIFF
--- a/server/dev-proxy.js
+++ b/server/dev-proxy.js
@@ -1,0 +1,18 @@
+/**
+Proxy allowing to develop locally while using wikia-dev domain
+To make it work run `npm run dev-proxy` and set proxy auto-config in your browser as in the gist:
+https://gist.github.com/rogatty/151a29205420f23f54138ca1b2dc92a7
+*/
+
+const http = require('http');
+const httpProxy = require('http-proxy');
+
+const proxy = httpProxy.createProxyServer({});
+const port = 7002;
+
+const server = http.createServer((req, res) => {
+	proxy.web(req, res, {target: 'http://127.0.0.1:7001'});
+});
+
+console.log(`proxy listening on port ${port}`);
+server.listen(port);


### PR DESCRIPTION
## Links

* https://chrome.google.com/webstore/detail/proxy-switchyomega/padekgcemlokbadohgkifijomclgjgif
* http://findproxyforurl.com/pac-file-introduction/
* https://github.com/nodejitsu/node-http-proxy
* https://gist.github.com/rogatty/151a29205420f23f54138ca1b2dc92a7

## Description

This allows to run mobile-wiki locally and access it using dev domain, e.g. `muppet.igor.wikia-dev.pl`. Browser extensions which are able to use PAC file will proxy the mobile-wiki requests to `dev-proxy.js` and ignore the rest of `wikia-dev.pl` (e.g. `services.wikia-dev.pl` or `muppet.igor.wikia-dev.pl/wikia.php`).

PAC rules: https://gist.github.com/rogatty/151a29205420f23f54138ca1b2dc92a7

## Reviewers

@Wikia/x-wing 