### PR TITLE
XW-4018 | updated translations for mobile apps in global footer

### DIFF
--- a/app/models/application.js
+++ b/app/models/application.js
@@ -16,7 +16,7 @@ export default EmberObject.extend({
 	currentUser: inject.service(),
 	fastboot: inject.service(),
 
-	fetch(title) {
+	fetch(title, uselangParam) {
 		const currentUser = this.get('currentUser'),
 			fastboot = this.get('fastboot'),
 			shoebox = fastboot.get('shoebox');
@@ -37,7 +37,7 @@ export default EmberObject.extend({
 					navigation: NavigationModel.create(ownerInjection).fetchAll(
 						host,
 						wikiVariablesData.id,
-						wikiVariablesData.language.content
+						uselangParam || wikiVariablesData.language.content
 					),
 					trackingDimensions: TrackingDimensionsModel.create(ownerInjection).fetch(
 						!userId,

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -53,7 +53,8 @@ export default Route.extend(
 				wikiPageTitle = transition.params['wiki-page'].title;
 			}
 
-			return ApplicationModel.create(getOwner(this).ownerInjection()).fetch(wikiPageTitle)
+			return ApplicationModel.create(getOwner(this).ownerInjection())
+				.fetch(wikiPageTitle, transition.queryParams.uselang)
 				.then((applicationData) => {
 					this.get('wikiVariables').setProperties(applicationData.wikiVariables);
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "broccoli-funnel": "2.0.1",
     "broccoli-merge-trees": "2.0.0",
     "broccoli-stew": "1.5.0",
-    "design-system-i18n": "github:wikia/design-system-i18n.git#1.0.0",
+    "design-system-i18n": "github:wikia/design-system-i18n.git#XW-4018",
     "ember-browserify": "1.2.0",
     "ember-cli": "2.15.1",
     "ember-cli-app-version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "broccoli-funnel": "2.0.1",
     "broccoli-merge-trees": "2.0.0",
     "broccoli-stew": "1.5.0",
-    "design-system-i18n": "github:wikia/design-system-i18n.git#XW-4018",
+    "design-system-i18n": "github:wikia/design-system-i18n.git#1.0.1",
     "ember-browserify": "1.2.0",
     "ember-cli": "2.15.1",
     "ember-cli-app-version": "3.1.0",


### PR DESCRIPTION
## Links

https://wikia-inc.atlassian.net/browse/XW-3821

## Description

Previously, design-system-i18n was fetched based on content language, and since in app it's based on userLang param we want mobile-wiki to behave the same way

## Reviewers

@Wikia/x-wing , 
@kvas-damian - is there any better way to pass "uselang" to that design-system call?
