### PR TITLE
XW-3104 | Fix showTitle in article-media-thumbnail.js

### DIFF
--- a/app/components/article-media-thumbnail.js
+++ b/app/components/article-media-thumbnail.js
@@ -45,7 +45,7 @@ export default Component.extend(
 		hasFigcaption: computed.or('caption', 'showTitle'),
 
 		showTitle: computed('type', function () {
-			return this.get('type') === 'video' || this.get('isOgg') && this.get('title');
+			return (this.get('type') === 'video' || this.get('isOgg')) && this.get('title');
 		}),
 
 		click(event) {


### PR DESCRIPTION
## Links

* https://github.com/Wikia/mobile-wiki/pull/176

## Description

A title should be shown only when there is a title.

## Reviewers

@Wikia/x-wing 