### PR TITLE
ADEN-5917 | Add line item id and creative id to kikimora video

### DIFF
--- a/app/components/article-featured-video.js
+++ b/app/components/article-featured-video.js
@@ -15,11 +15,7 @@ const {
 		observer,
 		setProperties
 	} = Ember,
-	autoplayCookieName = 'featuredVideoAutoplay',
-	playerTrackerParams = {
-		adProduct: 'featured-video-preroll',
-		slotName: 'FEATURED'
-	};
+	autoplayCookieName = 'featuredVideoAutoplay';
 
 export default Component.extend(InViewportMixin, {
 	classNames: ['article-featured-video'],
@@ -126,6 +122,10 @@ export default Component.extend(InViewportMixin, {
 			autoplay = this.get('autoplay'),
 			jsParams = {
 				autoplay,
+				adTrackingParams: {
+					adProduct: this.get('ads.noAds') ? 'featured-video-no-preroll' : 'featured-video-preroll',
+					slotName: 'FEATURED'
+				},
 				cacheBuster: this.get('wikiVariables.cacheBuster'),
 				containerId: this.get('videoContainerId'),
 				initialVolume: autoplay ? 0 : 1,
@@ -142,14 +142,6 @@ export default Component.extend(InViewportMixin, {
 			},
 			data = extend({}, model, {jsParams}),
 			videoLoader = new VideoLoader(data);
-
-		Ads.getInstance().onReady(() => {
-			Ads.getInstance().trackOoyalaEvent(playerTrackerParams, 'init');
-		});
-
-		if (this.get('ads.noAds')) {
-			playerTrackerParams.adProduct = 'featured-video-no-preroll';
-		}
 
 		videoLoader.loadPlayerClass();
 	},
@@ -170,8 +162,6 @@ export default Component.extend(InViewportMixin, {
 		const category = 'article-video';
 		let playTime = -1,
 			percentagePlayTime = -1;
-
-		Ads.getInstance().registerOoyalaTracker(player, playerTrackerParams);
 
 		player.mb.subscribe(window.OO.EVENTS.INITIAL_PLAY, 'featured-video', () => {
 			track({

--- a/app/modules/ads.js
+++ b/app/modules/ads.js
@@ -191,7 +191,7 @@ class Ads {
 
 		return this.vastUrlBuilder.build(aspectRatio, slotParams, options);
 	}
- 	
+
 	registerOoyalaTracker(player, params) {
 		if (!this.ooyalaTracker) {
 			console.warn('Can not use Ooyala tracker.');

--- a/app/modules/ads.js
+++ b/app/modules/ads.js
@@ -191,11 +191,7 @@ class Ads {
 
 		return this.vastUrlBuilder.build(aspectRatio, slotParams, options);
 	}
-
-	/**
-	 * Build VAST url for video players
-	 *
-	 */
+ 	
 	registerOoyalaTracker(player, params) {
 		if (!this.ooyalaTracker) {
 			console.warn('Can not use Ooyala tracker.');

--- a/app/modules/video-players/ooyala-v4.js
+++ b/app/modules/video-players/ooyala-v4.js
@@ -21,6 +21,7 @@ export default class OoyalaV4Player extends BasePlayer {
 		const ooyalaPCode = config.ooyala.pcode;
 		const ooyalaPlayerBrandingId = config.ooyala.playerBrandingId;
 		const skinConfigUrl = `/wikia.php?controller=OoyalaConfig&method=skin&isMobile=1&cb=${params.cacheBuster}`;
+		const originalOnCreate = params.onCreate;
 
 		params.pcode = ooyalaPCode;
 		params.playerBrandingId = ooyalaPlayerBrandingId;
@@ -30,6 +31,13 @@ export default class OoyalaV4Player extends BasePlayer {
 		params.skin.config = skinConfigUrl;
 
 		super(provider, params);
+		this.adTrackingParams = params.adTrackingParams;
+
+		params.onCreate = (player) => {
+			originalOnCreate(player);
+
+			Ads.getInstance().registerOoyalaTracker(player, this.adTrackingParams);
+		};
 
 		this.containerId = params.containerId;
 	}
@@ -52,7 +60,10 @@ export default class OoyalaV4Player extends BasePlayer {
 		window.OO.ready(() => {
 			Ads.getInstance()
 				.waitForReady()
-				.then(() => (new OoyalaVideoAds(this.params)).getOoyalaConfig())
+				.then(() => {
+					Ads.getInstance().trackOoyalaEvent(this.adTrackingParams, 'init');
+					return (new OoyalaVideoAds(this.params, this.adTrackingParams)).getOoyalaConfig();
+				})
 				.then((params) => window.OO.Player.create(this.containerId, this.params.videoId, params));
 		});
 	}

--- a/app/modules/video-players/ooyala-video-ads.js
+++ b/app/modules/video-players/ooyala-video-ads.js
@@ -3,8 +3,9 @@ import moatVideoTracker from './moat-video-tracker';
 
 export default class OoyalaVideoAds {
 
-	constructor(params) {
+	constructor(params, trackingParams) {
 		this.params = params;
+		this.trackingParams = trackingParams;
 	}
 
 	getOoyalaConfig() {
@@ -76,6 +77,13 @@ export default class OoyalaVideoAds {
 		if (Ads.getInstance().currentAdsContext.opts.isMoatTrackingForFeaturedVideoEnabled) {
 			moatVideoTracker(IMAAdsManager, uiContainer, window.google.ima.ViewMode.NORMAL, 'ooyala', 'featured-video');
 		}
+
+		IMAAdsManager.addEventListener('loaded', (eventData) => {
+			const adData = eventData.getAdData();
+
+			this.trackingParams.lineItemId = adData.adId;
+			this.trackingParams.creativeId = adData.creativeId;
+		});
 
 		// that's a hack for autoplay on mobile for VPAID ads
 		// VPAID ads still don't work perfectly


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/ADEN-5917

## Description

Passing value by reference isn't easy to understand, although we don't have access to `player` object inside `onAdRequestSuccess()` method (when we call this method `player` is not instantiated). So there is no easy way to update tracking on a player from that method. That's why I decided to go with reference magic.

Tracing events after we get ad response contains `line_item_id` and `creative_id`:
* started
* completed
* content_started
* content_completed

Events triggered before ad response don't contain that info.

## Reviewers

@rogatty @fraszczakszymon 
