### PR TITLE
IRIS-4949 | Use mercury-shared#2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "heapdump": "0.3.9",
     "i18next": "9.0.0",
     "loader.js": "4.6.0",
-    "mercury-shared": "github:wikia/mercury-shared#14991423567ff00985f7eea9c266a574debbebc9",
+    "mercury-shared": "github:wikia/mercury-shared#2.0.0",
     "moment": "2.18.1",
     "numeral": "2.0.6",
     "phantomjs-prebuilt": "2.1.15",


### PR DESCRIPTION
## Links

* https://github.com/Wikia/mercury-shared/releases/tag/2.0.0

## Description

Use version 2.0.0 instead of a commit hash. No code changes.