### PR TITLE
Liftigniter config fix

### DIFF
--- a/app/services/liftigniter.js
+++ b/app/services/liftigniter.js
@@ -55,10 +55,10 @@ export default Service.extend({
 					queryServer: '//query.fandommetrics.com'
 				},
 				activity: {
-					activityServer: '//api.fandommetrics.com'
+					activityServer: '//query.fandommetrics.com'
 				},
 				inventory: {
-					inventoryServer: '//api.fandommetrics.com'
+					inventoryServer: '//query.fandommetrics.com'
 				},
 				globalCtx: context,
 			}


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/PLATFORM-3230

## Description

While changing fandommetrics domain to petametrics we noticed our domains configuration is overridden on Liftigniter side. Litfigniter support disabled this config overridde in http://cdn.petametrics.com/l9ehhrb6mtv75bp2.js?ts=419126 library and we noticed mobile-wiki uses `api.` subdomain instead `query.`.
Everything works fine in app (https://github.com/Wikia/app/blob/d41d4ce68d9cba09b25e87755e7f4b9af25dd8dc/extensions/wikia/Recirculation/js/trackers/liftigniter.js#L54).

## Reviewers

@Wikia/x-wing 