### PR TITLE
Generate code coverage report

### DIFF
--- a/config/coverage.js
+++ b/config/coverage.js
@@ -1,0 +1,3 @@
+module.exports = {
+	useBabelInstrumenter: true
+};

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -6,6 +6,9 @@ import filePageFixture from './fixtures/file-page';
 export default function () {
 	this.passthrough('https://localhost/**');
 
+	this.passthrough('/write-coverage');
+	this.namespace = 'api';
+
 	this.passthrough('https://services.wikia-dev.pl/**');
 	this.passthrough('https://services.wikia-dev.us/**');
 	this.passthrough('https://services.wikia.com/**');

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "ember-cli-autoprefixer": "0.8.0",
     "ember-cli-babel": "6.8.2",
     "ember-cli-bidi": "github:wikia/ember-cli-bidi#dd6fd681c29eb02ab21eda53a16bf3f779183fc4",
+    "ember-cli-code-coverage": "0.4.2",
     "ember-cli-dependency-checker": "2.0.1",
     "ember-cli-deprecation-workflow": "0.2.3",
     "ember-cli-eslint": "4.2.0",


### PR DESCRIPTION
Allow to generate code coverage report (via [`ember-cli-code-coverage`](https://github.com/kategengler/ember-cli-code-coverage)) that can then be viewed in human readable HTML format or fed to the SonarQube continuous code quality system.

## How to generate code coverage report
Run `$ COVERAGE=true ember test`

It looks like [this](http://public.mszabo.wikia-dev.pl/coverage/coverage/) in HTML format