### PR TITLE
Exclude .git directory from Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,7 @@ Dockerfile.prod
 
 # misc
 .github/
+.git/
 .tx/
 /.sass-cache
 /connect.lock


### PR DESCRIPTION
Make the build context a bit smaller.

### Before
```
$ docker build -t mobile-wiki -f Dockerfile.dev .
Sending build context to Docker daemon  108.7MB
```
### After
```
$ docker build -t mobile-wiki -f Dockerfile.dev .
Sending build context to Docker daemon   2.15MB
```
