### PR TITLE
XW-4268 | change observer from init to didInsertElement

### DIFF
--- a/app/components/article-content.js
+++ b/app/components/article-content.js
@@ -36,7 +36,7 @@ export default Component.extend(
 		isPreview: false,
 		media: null,
 
-		articleContentObserver: on('init', observer('content', function () {
+		articleContentObserver: on('didInsertElement', observer('content', function () {
 			// Our hacks don't work in FastBoot, so we just inject raw HTML in the template
 			if (this.get('isFastBoot')) {
 				return;


### PR DESCRIPTION
## Links

https://wikia-inc.atlassian.net/browse/XW-4268

## Description
One of possible reasons of error from ticket may be exception thrown when `this.$()` is still undefined while calling it in `injectAds` method. `didInsertElement` ensures that `this.$()` is properly set: https://guides.emberjs.com/v2.16.0/components/the-component-lifecycle/#toc_integrating-with-third-party-libraries-with-code-didinsertelement-code

## Reviewers

@Wikia/x-wing 
