### PR TITLE
missing Promise import in modules/ads.js

### DIFF
--- a/app/modules/ads.js
+++ b/app/modules/ads.js
@@ -1,5 +1,6 @@
 /* eslint no-console: 0 */
 import config from '../config/environment';
+import {Promise} from 'rsvp';
 
 /**
  * @typedef {Object} SlotsContext


### PR DESCRIPTION
## Description

```{"message":"Undefined variable: Promise","stack":"<anonymous function: value>([arguments not available])@https://mobile-wiki.nocookie.net/mobile-wiki/assets/mobile-wiki-818921cb0ad754e6ef972385e568fbd8.js:712\n<anonymous function: value>([arguments not available])@https://mobile-wiki.nocookie.net/mobile-wiki/assets/mobile-wiki-818921cb0ad754e6ef972385e568fbd8.js:749\n<anonymous function: value>([arguments not available])@https://mobile-wiki.nocookie.net/mobile-wiki/assets/mobile-wiki-818921cb0ad754e6ef972385e568fbd8.js:750\n<anonymous function: value>([arguments not available])@https://mobile-wiki.nocookie.net/mobile-wiki/assets/mobile-wiki-818921cb0ad754e6ef972385e568fbd8.js:750\nc([arguments not available])@https://mobile-wiki.nocookie.net/mobile-wiki/assets/vendor-4b6d1773ba7e6991d252511e8f445122.js:3548\nb([arguments not available])@https://mobile-wiki.nocookie.net/mobile-wiki/assets/vendor-4b6d1773ba7e6991d252511e8f445122.js:3556\nv([arguments not available])@https://mobile-wiki.nocookie.net/mobile-wiki/assets/vendor-4b6d1773ba7e6991d252511e8f445122.js:3554\n<anonymous function: e.prototype.invokeWithOnError>([arguments not available])@https://mobile-wiki.nocookie.net/mobile-wiki/assets/vendor-4b6d1773ba7e6991d252511e8f445122.js:1493\n<anonymous function: e.prototype.flush>([arguments not available])@https://mobile-wiki.nocookie.net/mobile-wiki/assets/vendor-4b6d1773ba7e6991d252511e8f445122.js:1480\n<anonymous function: e.prototype.flush>([arguments not available])@https://mobile-wiki.nocookie.net/mobile-wiki/assets/vendor-4b6d1773ba7e6991d252511e8f445122.js:1496"}```

this error happens up to 1000/h

## Reviewers

@Wikia/x-wing 
@v3rth 
@fraszczakszymon 
