### PR TITLE
Refactor component render logic

### DIFF
--- a/app/components/ad-slot.js
+++ b/app/components/ad-slot.js
@@ -5,8 +5,10 @@ import {dasherize} from '@ember/string';
 import {on} from '@ember/object/evented';
 import {setProperties, computed} from '@ember/object';
 import InViewportMixin from 'ember-in-viewport';
+import RenderComponentMixin from '../mixins/render-component';
 
 export default Component.extend(
+	RenderComponentMixin,
 	InViewportMixin,
 	{
 		classNames: ['ad-slot-wrapper'],

--- a/app/components/ads/invisible-high-impact-2.js
+++ b/app/components/ads/invisible-high-impact-2.js
@@ -3,8 +3,9 @@ import {readOnly} from '@ember/object/computed';
 import {dasherize} from '@ember/string';
 import Component from '@ember/component';
 import {computed, get} from '@ember/object';
+import RenderComponentMixin from '../mixins/render-component';
 
-export default Component.extend({
+export default Component.extend(RenderComponentMixin, {
 	ads: service(),
 
 	highImpactCountries: get(Wikia, 'InstantGlobals.wgAdDriverHighImpact2SlotCountries'),

--- a/app/components/ads/invisible-high-impact-2.js
+++ b/app/components/ads/invisible-high-impact-2.js
@@ -3,7 +3,7 @@ import {readOnly} from '@ember/object/computed';
 import {dasherize} from '@ember/string';
 import Component from '@ember/component';
 import {computed, get} from '@ember/object';
-import RenderComponentMixin from '../mixins/render-component';
+import RenderComponentMixin from '../../mixins/render-component';
 
 export default Component.extend(RenderComponentMixin, {
 	ads: service(),

--- a/app/components/article-content.js
+++ b/app/components/article-content.js
@@ -52,6 +52,8 @@ export default Component.extend(
 
 					this.handleInfoboxes();
 					this.replaceInfoboxesWithInfoboxComponents();
+
+					// todo: add mixin for these
 					this.renderedComponents = this.renderedComponents.concat(
 						queryPlaceholders(this.$())
 							.map(getAttributesForMedia, {

--- a/app/components/article-content.js
+++ b/app/components/article-content.js
@@ -53,7 +53,6 @@ export default Component.extend(
 					this.handleInfoboxes();
 					this.replaceInfoboxesWithInfoboxComponents();
 
-					// todo: add mixin for these
 					this.renderedComponents = this.renderedComponents.concat(
 						queryPlaceholders(this.$())
 							.map(getAttributesForMedia, {

--- a/app/components/article-contribution.js
+++ b/app/components/article-contribution.js
@@ -1,8 +1,10 @@
 import Component from '@ember/component';
 import LanguagesMixin from '../mixins/languages';
 import {track, trackActions} from '../utils/track';
+import RenderComponentMixin from '../mixins/render-component';
 
 export default Component.extend(
+	RenderComponentMixin,
 	LanguagesMixin,
 	{
 		classNames: ['contribution-container'],

--- a/app/components/article-media-gallery.js
+++ b/app/components/article-media-gallery.js
@@ -4,8 +4,10 @@ import EmberObject, {computed} from '@ember/object';
 import Component from '@ember/component';
 import InViewportMixin from 'ember-in-viewport';
 import Thumbnailer from '../modules/thumbnailer';
+import RenderComponentMixin from '../mixins/render-component';
 
 export default Component.extend(
+	RenderComponentMixin,
 	InViewportMixin,
 	{
 		classNames: ['article-media-gallery'],

--- a/app/components/article-media-linked-gallery.js
+++ b/app/components/article-media-linked-gallery.js
@@ -4,50 +4,48 @@ import Component from '@ember/component';
 import Thumbnailer from '../modules/thumbnailer';
 import RenderComponentMixin from '../mixins/render-component';
 
-export default Component.extend(RenderComponentMixin,
-	{
-		classNames: ['article-media-linked-gallery'],
+export default Component.extend(RenderComponentMixin, {
+	classNames: ['article-media-linked-gallery'],
 
-		imageSize: 195,
-		cropMode: Thumbnailer.mode.topCrop,
-		numberOfItemsRendered: 4,
+	imageSize: 195,
+	cropMode: Thumbnailer.mode.topCrop,
+	numberOfItemsRendered: 4,
 
-		canShowMore: computed('items', 'numberOfItemsRendered', function () {
-			return this.get('items.length') > this.get('numberOfItemsRendered');
-		}),
+	canShowMore: computed('items', 'numberOfItemsRendered', function () {
+		return this.get('items.length') > this.get('numberOfItemsRendered');
+	}),
 
-		sortedItems: sort('sanitizedItems', (a, b) => {
-			if (a.isLinkedByUser && !b.isLinkedByUser) {
-				return 1;
-			} else if (b.isLinkedByUser && !a.isLinkedByUser) {
-				return -1;
-			}
+	sortedItems: sort('sanitizedItems', (a, b) => {
+		if (a.isLinkedByUser && !b.isLinkedByUser) {
+			return 1;
+		} else if (b.isLinkedByUser && !a.isLinkedByUser) {
+			return -1;
+		}
 
-			return 0;
-		}),
+		return 0;
+	}),
 
-		sanitizedItems: map('items', (item, index) => {
-			item.galleryRef = index;
-			return item;
-		}),
+	sanitizedItems: map('items', (item, index) => {
+		item.galleryRef = index;
+		return item;
+	}),
 
-		/**
-		 * We don't want to render all child components because galleries can be big
-		 * Initially, we render this.numberOfItemsRendered components
-		 * Then increment this number in this.showMore
-		 */
-		itemsToRender: computed('sortedItems', 'numberOfItemsRendered', function () {
-			return this.get('sortedItems').slice(0, this.get('numberOfItemsRendered'));
-		}),
+	/**
+	 * We don't want to render all child components because galleries can be big
+	 * Initially, we render this.numberOfItemsRendered components
+	 * Then increment this number in this.showMore
+	 */
+	itemsToRender: computed('sortedItems', 'numberOfItemsRendered', function () {
+		return this.get('sortedItems').slice(0, this.get('numberOfItemsRendered'));
+	}),
 
-		actions: {
-			openLightbox(galleryRef) {
-				// openLightbox is set in getAttributesForMedia() inside utils/article-media.js
-				this.get('openLightbox')(this.get('ref'), galleryRef);
-			},
-			showMore() {
-				this.set('numberOfItemsRendered', this.get('items.length'));
-			}
+	actions: {
+		openLightbox(galleryRef) {
+			// openLightbox is set in getAttributesForMedia() inside utils/article-media.js
+			this.get('openLightbox')(this.get('ref'), galleryRef);
 		},
-	}
-);
+		showMore() {
+			this.set('numberOfItemsRendered', this.get('items.length'));
+		}
+	},
+});

--- a/app/components/article-media-linked-gallery.js
+++ b/app/components/article-media-linked-gallery.js
@@ -2,8 +2,9 @@ import {sort, map} from '@ember/object/computed';
 import {computed} from '@ember/object';
 import Component from '@ember/component';
 import Thumbnailer from '../modules/thumbnailer';
+import RenderComponentMixin from '../mixins/render-component';
 
-export default Component.extend(
+export default Component.extend(RenderComponentMixin,
 	{
 		classNames: ['article-media-linked-gallery'],
 

--- a/app/components/article-media-map-thumbnail.js
+++ b/app/components/article-media-map-thumbnail.js
@@ -1,8 +1,9 @@
 import {inject as service} from '@ember/service';
 import Component from '@ember/component';
 import {track, trackActions} from '../utils/track';
+import RenderComponentMixin from '../mixins/render-component';
 
-export default Component.extend(
+export default Component.extend(RenderComponentMixin,
 	{
 		classNames: ['article-media-map-thumbnail'],
 		tagName: 'figure',

--- a/app/components/article-media-map-thumbnail.js
+++ b/app/components/article-media-map-thumbnail.js
@@ -3,37 +3,35 @@ import Component from '@ember/component';
 import {track, trackActions} from '../utils/track';
 import RenderComponentMixin from '../mixins/render-component';
 
-export default Component.extend(RenderComponentMixin,
-	{
-		classNames: ['article-media-map-thumbnail'],
-		tagName: 'figure',
-		logger: service(),
+export default Component.extend(RenderComponentMixin, {
+	classNames: ['article-media-map-thumbnail'],
+	tagName: 'figure',
+	logger: service(),
 
-		/**
-		 * @returns {void|boolean}
-		 */
-		click() {
-			const url = this.get('url'),
-				id = this.get('id'),
-				title = this.get('title');
+	/**
+	 * @returns {void|boolean}
+	 */
+	click() {
+		const url = this.get('url'),
+			id = this.get('id'),
+			title = this.get('title');
 
-			if (url) {
-				this.get('logger').debug('Handling map with id:', id, 'and title:', title);
+		if (url) {
+			this.get('logger').debug('Handling map with id:', id, 'and title:', title);
 
-				track({
-					action: trackActions.click,
-					category: 'map',
-					label: 'open'
-				});
+			track({
+				action: trackActions.click,
+				category: 'map',
+				label: 'open'
+			});
 
-				this.get('openLightbox')('map', {
-					id,
-					title,
-					url
-				});
+			this.get('openLightbox')('map', {
+				id,
+				title,
+				url
+			});
 
-				return false;
-			}
+			return false;
 		}
 	}
-);
+});

--- a/app/components/article-media-thumbnail.js
+++ b/app/components/article-media-thumbnail.js
@@ -7,8 +7,10 @@ import ViewportMixin from '../mixins/viewport';
 import MediaThumbnailUtilsMixin from '../mixins/media-thumbnail-utils';
 import Thumbnailer from '../modules/thumbnailer';
 import {normalizeThumbWidth} from '../utils/thumbnail';
+import RenderComponentMixin from '../mixins/render-component';
 
 export default Component.extend(
+	RenderComponentMixin,
 	InViewportMixin,
 	MediaThumbnailUtilsMixin,
 	ViewportMixin,

--- a/app/components/article-table-of-contents.js
+++ b/app/components/article-table-of-contents.js
@@ -2,9 +2,7 @@ import Component from '@ember/component';
 import {track, trackActions} from '../utils/track';
 import RenderComponentMixin from '../mixins/render-component';
 
-export default Component.extend(
-	RenderComponentMixin,
-	{
+export default Component.extend(RenderComponentMixin, {
 		classNames: ['table-of-contents'],
 		layoutName: 'components/article-table-of-contents',
 

--- a/app/components/article-table-of-contents.js
+++ b/app/components/article-table-of-contents.js
@@ -3,42 +3,41 @@ import {track, trackActions} from '../utils/track';
 import RenderComponentMixin from '../mixins/render-component';
 
 export default Component.extend(RenderComponentMixin, {
-		classNames: ['table-of-contents'],
-		layoutName: 'components/article-table-of-contents',
+	classNames: ['table-of-contents'],
+	layoutName: 'components/article-table-of-contents',
 
-		/**
-		 * Generates table of contents data based on h2 elements in the article
-		 * @todo https://wikia-inc.atlassian.net/browse/XW-1425
-		 * Temporary solution for generating Table of Contents
-		 * Ideally, we wouldn't be doing this as a post-processing step, but rather we would just get a JSON with
-		 * ToC data from server and render view based on that.
-		 *
-		 * @returns {void}
-		 */
-		didInsertElement() {
-			const headers = this.get('articleContent').find('h2[section]').map((i, elem) => {
-				if (elem.textContent) {
-					return {
-						element: elem,
-						level: elem.tagName,
-						name: elem.textContent,
-						id: elem.id,
-						section: elem.getAttribute('section'),
-					};
-				}
-			}).toArray();
-
-			this.set('headers', headers);
-		},
-
-		actions: {
-			trackClick(category, label) {
-				track({
-					action: trackActions.click,
-					category,
-					label
-				});
+	/**
+	 * Generates table of contents data based on h2 elements in the article
+	 * @todo https://wikia-inc.atlassian.net/browse/XW-1425
+	 * Temporary solution for generating Table of Contents
+	 * Ideally, we wouldn't be doing this as a post-processing step, but rather we would just get a JSON with
+	 * ToC data from server and render view based on that.
+	 *
+	 * @returns {void}
+	 */
+	didInsertElement() {
+		const headers = this.get('articleContent').find('h2[section]').map((i, elem) => {
+			if (elem.textContent) {
+				return {
+					element: elem,
+					level: elem.tagName,
+					name: elem.textContent,
+					id: elem.id,
+					section: elem.getAttribute('section'),
+				};
 			}
+		}).toArray();
+
+		this.set('headers', headers);
+	},
+
+	actions: {
+		trackClick(category, label) {
+			track({
+				action: trackActions.click,
+				category,
+				label
+			});
 		}
 	}
-);
+});

--- a/app/components/article-table-of-contents.js
+++ b/app/components/article-table-of-contents.js
@@ -1,7 +1,9 @@
 import Component from '@ember/component';
 import {track, trackActions} from '../utils/track';
+import RenderComponentMixin from '../mixins/render-component';
 
 export default Component.extend(
+	RenderComponentMixin,
 	{
 		classNames: ['table-of-contents'],
 		layoutName: 'components/article-table-of-contents',

--- a/app/components/jwplayer-tag.js
+++ b/app/components/jwplayer-tag.js
@@ -3,8 +3,9 @@ import Component from '@ember/component';
 import {Promise} from 'rsvp';
 import jwPlayerAssets from '../modules/jwplayer-assets';
 import {track} from '../utils/track';
+import RenderComponentMixin from '../mixins/render-component';
 
-export default Component.extend({
+export default Component.extend(RenderComponentMixin, {
 	jwVideoDataUrl: 'https://cdn.jwplayer.com/v2/media/',
 
 	/**

--- a/app/components/lightbox-ads.js
+++ b/app/components/lightbox-ads.js
@@ -1,7 +1,8 @@
 import {later} from '@ember/runloop';
 import Component from '@ember/component';
+import RenderComponentMixin from '../mixins/render-component';
 
-export default Component.extend({
+export default Component.extend(RenderComponentMixin, {
 	classNames: ['lightbox-ads', 'lightbox-content-inner'],
 
 	/**

--- a/app/components/lightbox-image.js
+++ b/app/components/lightbox-image.js
@@ -5,8 +5,10 @@ import {gt} from '@ember/object/computed';
 import Component from '@ember/component';
 import ViewportMixin from '../mixins/viewport';
 import ImageLoader from '../mixins/image-loader';
+import RenderComponentMixin from '../mixins/render-component';
 
 export default Component.extend(
+	RenderComponentMixin,
 	ViewportMixin,
 	ImageLoader,
 	{

--- a/app/components/lightbox-map.js
+++ b/app/components/lightbox-map.js
@@ -1,8 +1,9 @@
 import {scheduleOnce} from '@ember/runloop';
 import {observer} from '@ember/object';
 import Component from '@ember/component';
+import RenderComponentMixin from '../mixins/render-component';
 
-export default Component.extend({
+export default Component.extend(RenderComponentMixin, {
 	classNames: ['lightbox-map', 'lightbox-content-inner'],
 
 	modelObserver: observer('model', function () {

--- a/app/components/lightbox-media.js
+++ b/app/components/lightbox-media.js
@@ -6,8 +6,10 @@ import {observer, computed} from '@ember/object';
 import ThirdsClickMixin from '../mixins/thirds-click';
 import MediaModel from '../models/media';
 import {normalizeToUnderscore} from '../utils/string';
+import RenderComponentMixin from '../mixins/render-component';
 
 export default Component.extend(
+	RenderComponentMixin,
 	ThirdsClickMixin,
 	{
 		classNames: ['lightbox-media', 'lightbox-content-inner'],

--- a/app/components/lightbox-video.js
+++ b/app/components/lightbox-video.js
@@ -3,12 +3,14 @@ import {inject as service} from '@ember/service';
 import Component from '@ember/component';
 import ViewportMixin from '../mixins/viewport';
 import VideoLoader from '../modules/video-loader';
+import RenderComponentMixin from '../mixins/render-component';
 
 /**
  * Component that is used inside ligthbox-media component
  * to handle displaying video
  */
 export default Component.extend(
+	RenderComponentMixin,
 	ViewportMixin,
 	{
 		classNames: ['lightbox-video', 'lightbox-content-inner'],

--- a/app/components/lightbox-wrapper.js
+++ b/app/components/lightbox-wrapper.js
@@ -1,8 +1,9 @@
 import {not} from '@ember/object/computed';
 import {computed} from '@ember/object';
 import Component from '@ember/component';
+import RenderComponentMixin from '../mixins/render-component';
 
-export default Component.extend({
+export default Component.extend(RenderComponentMixin, {
 	classNames: ['lightbox-wrapper'],
 	classNameBindings: ['isVisible:open'],
 	// This is needed for keyDown event to work

--- a/app/components/portable-infobox-hero-image.js
+++ b/app/components/portable-infobox-hero-image.js
@@ -3,8 +3,10 @@ import {computed} from '@ember/object';
 import Component from '@ember/component';
 import Thumbnailer from '../modules/thumbnailer';
 import ViewportMixin from '../mixins/viewport';
+import RenderComponentMixin from '../mixins/render-component';
 
 export default Component.extend(
+	RenderComponentMixin,
 	ViewportMixin,
 	{
 		imageAspectRatio: 16 / 9,

--- a/app/components/portable-infobox-image-collection.js
+++ b/app/components/portable-infobox-image-collection.js
@@ -3,8 +3,9 @@ import {computed} from '@ember/object';
 import Component from '@ember/component';
 import Thumbnailer from '../modules/thumbnailer';
 import ViewportMixin from '../mixins/viewport';
+import RenderComponentMixin from '../mixins/render-component';
 
-export default Component.extend(
+export default Component.extend(RenderComponentMixin,
 	ViewportMixin,
 	{
 		classNames: ['pi-image-collection'],

--- a/app/components/portable-infobox-image-collection.js
+++ b/app/components/portable-infobox-image-collection.js
@@ -79,5 +79,4 @@ export default Component.extend(RenderComponentMixin,
 				this.set('currentImageIndex', newImageIndex);
 			}
 		}
-	}
-);
+	});

--- a/app/components/portable-infobox.js
+++ b/app/components/portable-infobox.js
@@ -1,9 +1,11 @@
 import {computed} from '@ember/object';
 import Component from '@ember/component';
 import ViewportMixin from '../mixins/viewport';
+import RenderComponentMixin from '../mixins/render-component';
 import {track, trackActions} from '../utils/track';
 
 export default Component.extend(
+	RenderComponentMixin,
 	ViewportMixin,
 	{
 		classNames: ['portable-infobox'],

--- a/app/components/widget-apester.js
+++ b/app/components/widget-apester.js
@@ -1,7 +1,8 @@
 import Component from '@ember/component';
 import WidgetScriptStateMixin from '../mixins/widget-script-state';
+import RenderComponentMixin from '../mixins/render-component';
 
-export default Component.extend(WidgetScriptStateMixin, {
+export default Component.extend(WidgetScriptStateMixin, RenderComponentMixin, {
 	classNames: ['widget-apester'],
 	data: null,
 

--- a/app/components/widget-flite.js
+++ b/app/components/widget-flite.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
+import RenderComponentMixin from '../mixins/render-component';
 
-export default Component.extend({
+export default Component.extend(RenderComponentMixin, {
 	classNames: ['widget-flite'],
 	layoutName: 'components/widget-flite',
 	data: null,

--- a/app/components/widget-playbuzz.js
+++ b/app/components/widget-playbuzz.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
+import RenderComponentMixin from '../mixins/render-component';
 
-export default Component.extend({
+export default Component.extend(RenderComponentMixin, {
 	classNames: ['widget-playbuzz'],
 	data: null,
 

--- a/app/components/widget-polldaddy.js
+++ b/app/components/widget-polldaddy.js
@@ -1,7 +1,8 @@
 import $ from 'jquery';
 import Component from '@ember/component';
+import RenderComponentMixin from '../mixins/render-component';
 
-export default Component.extend({
+export default Component.extend(RenderComponentMixin, {
 	classNames: ['widget-polldaddy'],
 	layoutName: 'components/widget-polldaddy',
 	data: null,

--- a/app/components/widget-twitter.js
+++ b/app/components/widget-twitter.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import {observer} from '@ember/object';
 import Component from '@ember/component';
 import WidgetScriptStateMixin from '../mixins/widget-script-state';
+import RenderComponentMixin from '../mixins/render-component';
 
 /**
  * Widgets
@@ -22,6 +23,7 @@ import WidgetScriptStateMixin from '../mixins/widget-script-state';
  */
 
 export default Component.extend(
+	RenderComponentMixin,
 	WidgetScriptStateMixin,
 	{
 		classNames: ['widget-twitter'],

--- a/app/components/widget-vk.js
+++ b/app/components/widget-vk.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import {observer} from '@ember/object';
 import Component from '@ember/component';
 import WidgetScriptStateMixin from '../mixins/widget-script-state';
+import RenderComponentMixin from '../mixins/render-component';
 
 /**
  * Widgets
@@ -22,6 +23,7 @@ import WidgetScriptStateMixin from '../mixins/widget-script-state';
  */
 
 export default Component.extend(
+	RenderComponentMixin,
 	WidgetScriptStateMixin,
 	{
 		classNames: ['widget-vk'],

--- a/app/mixins/render-component.js
+++ b/app/mixins/render-component.js
@@ -1,0 +1,12 @@
+import {on} from '@ember/object/evented';
+import Mixin from '@ember/object/mixin';
+
+export default Mixin.create({
+	replacePlaceholder: on('didInsertElement', function () {
+		if (this.placeholderElement) {
+			this.placeholderElement.parentNode.insertBefore(this.element, this.placeholderElement);
+			$(this.placeholderElement).remove();
+			this.placeholderElement = null;
+		}
+	}),
+});

--- a/app/mixins/render-component.js
+++ b/app/mixins/render-component.js
@@ -2,11 +2,11 @@ import {on} from '@ember/object/evented';
 import Mixin from '@ember/object/mixin';
 
 export default Mixin.create({
-	replacePlaceholder: on('didInsertElement', function () {
-		if (this.placeholderElement) {
-			this.placeholderElement.parentNode.insertBefore(this.element, this.placeholderElement);
-			$(this.placeholderElement).remove();
-			this.placeholderElement = null;
+	_replacePlaceholder: on('didInsertElement', function () {
+		if (this._placeholderElement) {
+			this._placeholderElement.parentNode.insertBefore(this.element, this._placeholderElement);
+			$(this._placeholderElement).remove();
+			this._placeholderElement = null;
 		}
 	}),
 });

--- a/app/utils/render-component.js
+++ b/app/utils/render-component.js
@@ -39,7 +39,7 @@ export function getRenderComponentFor(parent) {
 		 * @type {string}
 		 */
 		attrs.layoutName = `components/${name}`;
-		attrs.placeholderElement = placeholderElement;
+		attrs._placeholderElement = placeholderElement;
 
 		let componentInstance = component.create(attrs);
 		componentInstance.renderer.appendTo(componentInstance, placeholderElement.parentNode);

--- a/app/utils/render-component.js
+++ b/app/utils/render-component.js
@@ -39,21 +39,22 @@ export function getRenderComponentFor(parent) {
 		 * @type {string}
 		 */
 		attrs.layoutName = `components/${name}`;
+		attrs.placeholderElement = placeholderElement;
 
 		let componentInstance = component.create(attrs);
 		componentInstance.renderer.appendTo(componentInstance, placeholderElement.parentNode);
 
-		scheduleOnce('afterRender', this, () => {
-			if (componentInstance.element instanceof Node) {
-				placeholderElement.parentNode.insertBefore(componentInstance.element, placeholderElement);
-				$(placeholderElement).remove();
-			} else {
-				logEvent('render-component--element', {
-					componentName: name,
-					componentInstanceElement: JSON.stringify(componentInstance.element),
-				});
-			}
-		});
+		// scheduleOnce('afterRender', this, () => {
+		// 	if (componentInstance.element instanceof Node) {
+		// 		placeholderElement.parentNode.insertBefore(componentInstance.element, placeholderElement);
+		// 		$(placeholderElement).remove();
+		// 	} else {
+		// 		logEvent('render-component--element', {
+		// 			componentName: name,
+		// 			componentInstanceElement: JSON.stringify(componentInstance.element),
+		// 		});
+		// 	}
+		// });
 
 		return componentInstance;
 	};

--- a/app/utils/render-component.js
+++ b/app/utils/render-component.js
@@ -44,18 +44,6 @@ export function getRenderComponentFor(parent) {
 		let componentInstance = component.create(attrs);
 		componentInstance.renderer.appendTo(componentInstance, placeholderElement.parentNode);
 
-		// scheduleOnce('afterRender', this, () => {
-		// 	if (componentInstance.element instanceof Node) {
-		// 		placeholderElement.parentNode.insertBefore(componentInstance.element, placeholderElement);
-		// 		$(placeholderElement).remove();
-		// 	} else {
-		// 		logEvent('render-component--element', {
-		// 			componentName: name,
-		// 			componentInstanceElement: JSON.stringify(componentInstance.element),
-		// 		});
-		// 	}
-		// });
-
 		return componentInstance;
 	};
 }

--- a/tests/unit/components/article-content-test.js
+++ b/tests/unit/components/article-content-test.js
@@ -4,8 +4,10 @@ import {computed} from '@ember/object';
 import {run} from '@ember/runloop';
 import sinon from 'sinon';
 import {test, moduleForComponent} from 'ember-qunit';
+import {on} from '@ember/object/evented';
+import RenderComponentMixin from 'mobile-wiki/mixins/render-component';
 
-const adSlotComponentStub = Component.extend({
+const adSlotComponentStub = Component.extend(RenderComponentMixin, {
 	classNameBindings: ['nameLowerCase'],
 	nameLowerCase: computed('name', function () {
 		return dasherize(this.get('name').toLowerCase());

--- a/tests/unit/components/article-content-test.js
+++ b/tests/unit/components/article-content-test.js
@@ -4,7 +4,6 @@ import {computed} from '@ember/object';
 import {run} from '@ember/runloop';
 import sinon from 'sinon';
 import {test, moduleForComponent} from 'ember-qunit';
-import {on} from '@ember/object/evented';
 import RenderComponentMixin from 'mobile-wiki/mixins/render-component';
 
 const adSlotComponentStub = Component.extend(RenderComponentMixin, {


### PR DESCRIPTION
## Description

In some circumstances (probably race condition between component lifecycle and ember runloop queues) this error occurs:
```
{"message":"Failed to execute 'insertBefore' on 'Node': parameter 1 is not of type 'Node'.","stack":"TypeError: Failed to execute 'insertBefore' on 'Node': parameter 1 is not of type 'Node'.
    at o.<anonymous> (https://mobile-wiki.nocookie.net/mobile-wiki/assets/mobile-wiki-85317715ef759a92de257b363590464d.js:943:89)
    at e.invokeWithOnError (https://mobile-wiki.nocookie.net/mobile-wiki/assets/vendor-141447fcfc13538932323b19b5548465.js:1493:250)
    at e.flush (https://mobile-wiki.nocookie.net/mobile-wiki/assets/vendor-141447fcfc13538932323b19b5548465.js:1480:172)
    at e.flush (https://mobile-wiki.nocookie.net/mobile-wiki/assets/vendor-141447fcfc13538932323b19b5548465.js:1496:15)
    at e.end (https://mobile-wiki.nocookie.net/mobile-wiki/assets/vendor-141447fcfc13538932323b19b5548465.js:1504:9)
    at _boundAutorunEnd (https://mobile-wiki.nocookie.net/mobile-wiki/assets/vendor-141447fcfc13538932323b19b5548465.js:1500:388)"}
```

which refers to this line: https://github.com/Wikia/mobile-wiki/blob/fe664b97d564a39955bda33ed50553daab8439a5/app/utils/render-component.js#L48

after introducing more detailed logging we saw that in most cases it is related to rendering `ad-slot` and `invisible-hight-impact-2` components (~1500 occurrences per hour) but from time to time other components are also affected.

To resolve this issue we'd like to change way how some of the components are rendered

## Reviewers

@Wikia/x-wing 
@fraszczakszymon 
@v3rth 
@rogatty 