### PR TITLE
remove transaction from logging object

### DIFF
--- a/glimmer-error-temp/vendor-477163101f3d2b2bc93706778c45b91e.js
+++ b/glimmer-error-temp/vendor-477163101f3d2b2bc93706778c45b91e.js
@@ -1367,7 +1367,6 @@ Ne(this,e),this._macros=null,this._transaction=null,this.program=new ir,this.app
 	if (window) {
 		if (this._transaction && window.wikiaLogEvent) {
 			window.wikiaLogEvent('glimmer error', {
-				transaction: this._transaction,
 				stacktrace: window.wikiaGlimmerErrorStackTrace
 			});
 		}


### PR DESCRIPTION
Removed `transaction` because sometimes it causes error while stringifying to json.
@Wikia/x-wing 