### PR TITLE
rename router to _routerMicrolib

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -236,7 +236,7 @@ export default Route.extend(
 			 * @returns {void}
 			 */
 			handleLink(target) {
-				const currentRoute = this.router.get('currentRouteName');
+				const currentRoute = this._routerMicrolib.get('currentRouteName');
 
 				let title,
 					trackingCategory,


### PR DESCRIPTION
https://emberjs.com/deprecations/v2.x/#toc_ember-router-router-renamed-to-ember-router-_routermicrolib