### PR TITLE
update apps workload API version

### DIFF
--- a/k8s/k8s-descriptor-template-preview.yaml
+++ b/k8s/k8s-descriptor-template-preview.yaml
@@ -15,12 +15,15 @@ spec:
     app: mobile-wiki-preview
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mobile-wiki-preview
   namespace: prod
 spec:
+  selector:
+    matchLabels:
+      app: mobile-wiki-preview
   replicas: 1 #TODO: adjust - tests on preview may kill single instance
   selector:
     matchLabels:

--- a/k8s/k8s-descriptor-template-prod.yaml
+++ b/k8s/k8s-descriptor-template-prod.yaml
@@ -15,12 +15,15 @@ spec:
     app: mobile-wiki-prod
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mobile-wiki-prod
   namespace: prod
 spec:
+  selector:
+    matchLabels:
+      app: mobile-wiki-prod
   replicas: 8
   selector:
     matchLabels:

--- a/k8s/k8s-descriptor-template-sandbox.yaml
+++ b/k8s/k8s-descriptor-template-sandbox.yaml
@@ -15,12 +15,15 @@ spec:
     app: mobile-wiki-${env}
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mobile-wiki-${env}
   namespace: prod
 spec:
+  selector:
+    matchLabels:
+      app: mobile-wiki-${env}
   replicas: 1
   selector:
     matchLabels:

--- a/k8s/k8s-descriptor-template-stable.yaml
+++ b/k8s/k8s-descriptor-template-stable.yaml
@@ -15,12 +15,15 @@ spec:
     app: mobile-wiki-stable
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mobile-wiki-stable
   namespace: prod
 spec:
+  selector:
+    matchLabels:
+      app: mobile-wiki-stable
   replicas: 1 #TODO: adjust
   selector:
     matchLabels:

--- a/k8s/k8s-descriptor-template-staging.yaml
+++ b/k8s/k8s-descriptor-template-staging.yaml
@@ -15,12 +15,15 @@ spec:
     app: mobile-wiki-staging
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mobile-wiki-staging
   namespace: staging
 spec:
+  selector:
+    matchLabels:
+      app: mobile-wiki-staging
   replicas: 1 #TODO: adjust - tests on preview may kill single instance
   selector:
     matchLabels:

--- a/k8s/k8s-descriptor-template-verify.yaml
+++ b/k8s/k8s-descriptor-template-verify.yaml
@@ -15,12 +15,15 @@ spec:
     app: mobile-wiki-verify
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mobile-wiki-verify
   namespace: prod
 spec:
+  selector:
+    matchLabels:
+      app: mobile-wiki-verify
   replicas: 1 #TODO: adjust - tests on preview may kill single instance
   selector:
     matchLabels:


### PR DESCRIPTION
In k8s 1.9 apps workload API was marked as stable with name `apps/v1`. Old naming schema is deprecated and will be removed. So let's use proper API version.