### PR TITLE
(PLATFORM-3368) Fix redirects duplicating query parameters

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -177,7 +177,7 @@ export default Route.extend(
 
 				fastboot.get('response.headers').set(
 					'location',
-					`${basePath}${fastbootRequest.get('path')}${getQueryString(fastbootRequest.get('queryParams'))}`
+					`${basePath}${fastbootRequest.get('path')}`
 				);
 				fastboot.set('response.statusCode', 301);
 


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/PLATFORM-3368

## Description

Redirects due to domain aliases or going from HTTP to HTTPS were
duplicating the query parameters because fastboot.request.path includes
the query parameters. For http://starwars.wikia.com/wiki/Slicer?foo=bar
the path is equal to `/wiki/Slicer?foo=bar` so there's no need to also add
the query parameters again.

## Reviewers

@Wikia/core-platform-team @Wikia/x-wing @rogatty 
