### PR TITLE
XW-4311 | Logging anomallies in tracked url

### DIFF
--- a/app/utils/analyzeTrackedUrl.js
+++ b/app/utils/analyzeTrackedUrl.js
@@ -11,9 +11,13 @@ export default function analyzeTrackedUrl(params) {
 		return;
 	}
 
-	const page = tracker.get('page');
+	const gaPage = tracker.get('page');
+	const actualUrl = window.location.href;
 
-	if (window.location.href.indexOf(page) === -1) {
-		logEvent('GA url does not match window.location', params);
+	if (actualUrl.indexOf(gaPage) === -1) {
+		logEvent('GA url does not match window.location', Object.assign({
+			gaPage,
+			actualUrl
+		}, params));
 	}
 }

--- a/app/utils/analyzeTrackedUrl.js
+++ b/app/utils/analyzeTrackedUrl.js
@@ -1,0 +1,19 @@
+import logEvent from '../modules/event-logger';
+
+export default function analyzeTrackedUrl(params) {
+	if (!window.ga || typeof window.ga.getAll !== 'function') {
+		return;
+	}
+
+	const tracker = window.ga.getAll()[0];
+
+	if (!tracker) {
+		return;
+	}
+
+	const page = tracker.get('page');
+
+	if (window.location.href.indexOf(page) === -1) {
+		logEvent('GA url does not match window.location', params);
+	}
+}

--- a/app/utils/track.js
+++ b/app/utils/track.js
@@ -2,6 +2,7 @@
 
 import Ads from '../modules/ads';
 import {getGroup} from '../modules/abtest';
+import analyzeTrackedUrl from './analyzeTrackedUrl';
 
 /**
  * @typedef {Object} TrackContext
@@ -150,6 +151,9 @@ export function track(params) {
 		}
 
 		M.tracker.UniversalAnalytics.track(category, action, label, value, isNonInteractive);
+
+		// XW-4311 Added to determine if we're updating GA urls properly
+		analyzeTrackedUrl(params);
 	}
 
 	if (trackingMethod === 'both' || trackingMethod === 'internal') {


### PR DESCRIPTION
This logs a situation where a tracked url is not a part of window.location.href = badly tracked url.

This is to find out:
* If the root cause to tracking problems is us not updating the url properly
* How many events are affected by this (this might be unrelated to featured video)
* On what specific urls does it happen
