### PR TITLE
XW-4785 | get internal tracking data from shoebox instead of head data store - to preview

### DIFF
--- a/app/inline-scripts/tracking-internal.js
+++ b/app/inline-scripts/tracking-internal.js
@@ -3,8 +3,10 @@
 		return;
 	}
 
+	const shoeboxTrackingData = JSON.parse(document.querySelector('#shoebox-trackingData').innerHTML);
+
 	M.tracker.Internal.trackPageView({
-		a: M.getFromHeadDataStore('articleId'),
-		n: M.getFromHeadDataStore('namespace')
+		a: shoeboxTrackingData.articleId,
+		n: shoeboxTrackingData.namespace
 	});
 })(window.M);

--- a/app/mixins/wiki-page-handler.js
+++ b/app/mixins/wiki-page-handler.js
@@ -95,10 +95,9 @@ export default Mixin.create({
 						}
 
 						shoebox.put('wikiPage', dataForShoebox);
-						this.get('simpleStore').setProperties({
-							namespace: get(dataForShoebox, 'data.ns'),
-							articleId: get(dataForShoebox, 'data.details.id'),
-							isMainPage: get(dataForShoebox, 'data.isMainPage')
+						shoebox.put('trackingData', {
+							articleId: dataForShoebox.data.details.id,
+							namespace: dataForShoebox.data.ns
 						});
 					}
 

--- a/app/mixins/wiki-page-handler.js
+++ b/app/mixins/wiki-page-handler.js
@@ -96,8 +96,8 @@ export default Mixin.create({
 
 						shoebox.put('wikiPage', dataForShoebox);
 						shoebox.put('trackingData', {
-							articleId: dataForShoebox.data.details.id,
-							namespace: dataForShoebox.data.ns
+							articleId: get(dataForShoebox, 'data.details.id'),
+							namespace: get(dataForShoebox, 'data.ns')
 						});
 					}
 


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/XW-4785
* https://github.com/Wikia/mobile-wiki/pull/491

## Description

articleId and namespace was not set in data-head-store, thus undefined was sent for these fields to internal datawarehouse. This is temporary fix, ticket will be created to cleanup.

## Reviewers
@Wikia/x-wing 
