### PR TITLE
XW | Fix horizontal scroll on main pages

### DIFF
--- a/app/styles/component/_featured-content.scss
+++ b/app/styles/component/_featured-content.scss
@@ -4,6 +4,7 @@
 
 	height: 56.25vw;
 	margin-bottom: $featured-content-margin-bottom;
+	overflow: hidden;
 	position: relative;
 	width: 100%;
 


### PR DESCRIPTION
There are 2 icons on left and right when rotated they go over screen