### PR TITLE
lowercase custom dimensions

### DIFF
--- a/app/routes/wiki-page.js
+++ b/app/routes/wiki-page.js
@@ -293,7 +293,7 @@ export default Route.extend(
 			// update UA dimensions
 			if (model.adsContext) {
 				uaDimensions[3] = model.adsContext.targeting.wikiVertical;
-				uaDimensions[14] = model.adsContext.opts.showAds ? 'Yes' : 'No';
+				uaDimensions[14] = model.adsContext.opts.showAds ? 'yes' : 'no';
 			}
 			if (articleType) {
 				uaDimensions[19] = articleType;
@@ -303,8 +303,8 @@ export default Route.extend(
 			}
 
 			uaDimensions[21] = model.get('id');
-			uaDimensions[28] = model.get('hasPortableInfobox') ? 'Yes' : 'No';
-			uaDimensions[29] = model.get('featuredVideo') ? 'Yes' : 'No';
+			uaDimensions[28] = model.get('hasPortableInfobox') ? 'yes' : 'no';
+			uaDimensions[29] = model.get('featuredVideo') ? 'yes' : 'no';
 
 			setTrackContext({
 				a: model.get('id'),


### PR DESCRIPTION
it appears that something normalizes it to lowercase
don't know what it is
but currently in GA we have some events with Yes and some with yes
this is making generating reports harder

let's just default to lowercase
