### PR TITLE
Just install deps from npm on PR checks

### DIFF
--- a/tasks/jenkins/pr-checks.sh
+++ b/tasks/jenkins/pr-checks.sh
@@ -38,26 +38,13 @@ failTests() {
 
 # $1 - directory
 setupNpm() {
-	oldPath=$(pwd)
-	md5old=$(md5sum ${dependenciesDir}${1}package-lock.json | sed -e "s#\(^.\{32\}\).*#\1#")
-	md5new=$(md5sum .${1}package-lock.json | sed -e "s#\(^.\{32\}\).*#\1#")
-	sourceTarget="${dependenciesDir}${1}node_modules .${1}node_modules"
+	updateGit "Setup" pending "updating node modules in .${1}"
+	npm install --no-save || error=true
 
-	if [ "$md5new" = "$md5old" ]
+	if [[ ! -z $error ]]
 	then
-		ln -s $sourceTarget
-	else
-		cp -R $sourceTarget
-		updateGit "Setup" pending "updating node modules in .${1}"
-		cd ".${1}"
-		npm install --no-save || error=true
-		cd $oldPath
-
-		if [[ ! -z $error ]]
-		then
-			updateGit "Setup" failure "failed on: updating node modules in .${1}"
-			failTests && exit 1
-		fi
+		updateGit "Setup" failure "failed on: updating node modules in .${1}"
+		failTests && exit 1
 	fi
 
 	npm install -g greenkeeper-lockfile@1
@@ -70,7 +57,7 @@ updateGit "Tests" pending pending
 updateGit "Linter" pending pending
 
 ### Setup - node_modules
-setupNpm "/"
+setupNpm
 
 if [ -z $error ]
 then

--- a/tasks/jenkins/pr-checks.sh
+++ b/tasks/jenkins/pr-checks.sh
@@ -43,7 +43,7 @@ setupNpm() {
 
 	if [[ ! -z $error ]]
 	then
-		updateGit "Setup" failure "failed on: updating node modules in .${1}"
+		updateGit "Setup" failure "failed on: updating node modules"
 		failTests && exit 1
 	fi
 


### PR DESCRIPTION
using our custom node_modules cache increases complexity of the system
and I don't see it improving PR checks speed
3:01 - 3:24 - with our custom cache
3:01 - 3:13 - with installing straight from npm (once it took 2:10)