### PR TITLE
fix featured content alignment

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -41,7 +41,8 @@ module.exports = function (defaults) {
 	const app = new EmberApp(defaults, {
 		autoprefixer: {
 			cascade: false,
-			map: false
+			map: false,
+			remove: false
 		},
 		derequire: {
 			patterns: [


### PR DESCRIPTION
Autoprefixer is removing `-webkit-box-orient: vertical;` style from clamp mixin.
This PR disable removing outdated prefixes from css.
I've checked diff - disabling this feature causes just bringing back above style, no other changes. 
@Wikia/x-wing
