### PR TITLE
XW-4829 | try/catch around destroyAdSlotComponents

### DIFF
--- a/app/routes/wiki-page.js
+++ b/app/routes/wiki-page.js
@@ -18,6 +18,7 @@ import {
 	namespace as mediawikiNamespace,
 	isContentNamespace
 } from '../utils/mediawiki-namespace';
+import {logError} from '../modules/event-logger';
 
 export default Route.extend(
 	WikiPageHandlerMixin,
@@ -185,7 +186,13 @@ export default Route.extend(
 				// notify a property change on soon to be stale model for observers (like
 				// the Table of Contents menu) can reset appropriately
 				this.notifyPropertyChange('displayTitle');
-				this.get('ads').destroyAdSlotComponents();
+
+				try {
+					this.get('ads').destroyAdSlotComponents();
+				} catch (e) {
+					logError('destroyAdSlotComponents', e);
+				}
+
 				this.get('lightbox').close();
 			},
 


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/XW-4829
* more relevant links

## Description

`try/catch` around `destroyAdsComponents` invocation to prevent throwing `glimmer transaction` error.

## Reviewers

@Wikia/x-wing 
