### PR TITLE
(PLATFORM-3478) Upgrade jwplayer-fandom to 1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11822,7 +11822,7 @@
       "dev": true
     },
     "jwplayer-fandom": {
-      "version": "github:wikia/jwplayer-fandom#50e827dc387c03320c930d95b49be77b948905a0"
+      "version": "github:wikia/jwplayer-fandom#2ca0863393e3d9195cd2d4af79874ce0e025b522"
     },
     "kind-of": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "fastboot-app-server": "1.1.0",
     "hammerjs": "2.0.8",
     "js-cookie": "2.2.0",
-    "jwplayer-fandom": "github:wikia/jwplayer-fandom#1.4.1",
+    "jwplayer-fandom": "github:wikia/jwplayer-fandom#1.4.2",
     "lazysizes": "4.0.1",
     "method-override": "2.3.10",
     "on-headers": "1.0.1",


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/PLATFORM-3478
* https://github.com/Wikia/jwplayer-fandom/pull/48

## Description

Upgrade jwplayer-fandom to 1.4.2 to fix mixed content issue in tracking pixel.

## Reviewers

/cc @Wikia/core-platform-team @Wikia/x-wing 
