### PR TITLE
IRIS-6105 | Fallback to zh-hant for traditional chinese languages

### DIFF
--- a/app/services/i18n.js
+++ b/app/services/i18n.js
@@ -15,9 +15,14 @@ export default Service.extend({
 
 		if (fastboot.get('isFastBoot')) {
 			const fs = FastBoot.require('fs');
+			// Per MediaWiki's /languages/messages/MessagesZh_*.php
+			const traditionalChineseLanguages = ['zh-hk', 'zh-mo', 'zh-tw'];
 
 			config.translationsNamespaces.forEach((namespace) => {
 				[language, language.split('-')[0], 'en'].some((lang) => {
+					if (traditionalChineseLanguages.indexOf(lang) > -1) {
+						lang = 'zh-hant';
+					}
 					const translationPath = `dist/mobile-wiki/locales/${lang}/${namespace}.json`;
 
 					try {


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/IRIS-6105
* https://github.com/Wikia/discussions-front-end/pull/221

## Description
Change i18next fallback for zh-hk, zh-mo and zh-tw to zh-hant per:
- [MessagesZh_tw.php](https://github.com/Wikia/app/blob/a90fa39e4678343e66cd31d710094c9ad6c07fba/languages/messages/MessagesZh_tw.php#L25)
- [MessagesZh_hk.php](https://github.com/Wikia/app/blob/a90fa39e4678343e66cd31d710094c9ad6c07fba/languages/messages/MessagesZh_hk.php#L21)
- [MessagesZh_mo.php](https://github.com/Wikia/app/blob/a90fa39e4678343e66cd31d710094c9ad6c07fba/languages/messages/MessagesZh_mo.php#L13)