### PR TITLE
XW-4854 | Preserve image aspect ratios for portable infobox galleries

### DIFF
--- a/app/styles/module/article/_portable-infobox.scss
+++ b/app/styles/module/article/_portable-infobox.scss
@@ -112,6 +112,7 @@ $group-header-font-size: 16px;
 		.article-media-placeholder {
 			height: auto;
 			max-height: 100vw;
+			object-fit: contain;
 			width: 100%;
 		}
 


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/XW-4854
* support ticket [#399573](https://support.wikia-inc.com/hc/requests/399573)
* resolves #775

## Description

This fix prevents portrait images from being stretched. Support for `object-fit` [seems reasonable](https://caniuse.com/#feat=object-fit) on mobile.

![Screenshot](https://user-images.githubusercontent.com/1405147/41937194-0909ac32-79d3-11e8-87e7-e98ddfb42874.png)

PI galleries comprising landscape images of the same aspect ratio continue to not be letterboxed.

![Screenshot](https://user-images.githubusercontent.com/1405147/41937206-0e0dd532-79d3-11e8-836b-13427a4376b1.png)

PI galleries with a mix of image aspect ratios continue to size the stage up to 1:1 of the viewport's width.

![Screenshot](https://user-images.githubusercontent.com/1405147/41937209-10fd4156-79d3-11e8-9a17-396aa55bfe0a.png)

## Reviewers

* TBD
