### PR TITLE
PLATFORM-3543: surrogate keys for purging the whole wiki

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -149,6 +149,12 @@ export default Route.extend(
 				// https://www.fastly.com/blog/best-practices-for-using-the-vary-header
 				fastboot.get('response.headers').set('vary', 'cookie,accept-encoding');
 				fastboot.get('response.headers').set('Content-Language', model.wikiVariables.language.content);
+				const surrogateKey = model.wikiVariables.surrogateKey;
+				if (surrogateKey) {
+					fastboot.get('response.headers').set('Surrogate-Key',
+						[surrogateKey, surrogateKey + '-mobile-wiki'].join(' '));
+				}
+
 
 				// TODO remove `transition.queryParams.page`when icache supports surrogate keys
 				// and we can purge the category pages

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -149,10 +149,14 @@ export default Route.extend(
 				// https://www.fastly.com/blog/best-practices-for-using-the-vary-header
 				fastboot.get('response.headers').set('vary', 'cookie,accept-encoding');
 				fastboot.get('response.headers').set('Content-Language', model.wikiVariables.language.content);
-				const surrogateKey = model.wikiVariables.surrogateKey;
+
+				// Send per-wiki surrogate key header
+				let surrogateKey = model.wikiVariables.surrogateKey;
 				if (surrogateKey) {
-					fastboot.get('response.headers').set('Surrogate-Key',
-						[surrogateKey, `${surrogateKey}-mobile-wiki`].join(' '));
+					// append mobile-wiki specific key
+					surrogateKey = `${surrogateKey} ${surrogateKey}-mobile-wiki`;
+					fastboot.get('response.headers').set('Surrogate-Key', surrogateKey);
+					fastboot.get('response.headers').set('X-Surrogate-Key', surrogateKey);
 				}
 
 				// TODO remove `transition.queryParams.page`when icache supports surrogate keys

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -152,9 +152,8 @@ export default Route.extend(
 				const surrogateKey = model.wikiVariables.surrogateKey;
 				if (surrogateKey) {
 					fastboot.get('response.headers').set('Surrogate-Key',
-						[surrogateKey, surrogateKey + '-mobile-wiki'].join(' '));
+						[surrogateKey, `${surrogateKey}-mobile-wiki`].join(' '));
 				}
-
 
 				// TODO remove `transition.queryParams.page`when icache supports surrogate keys
 				// and we can purge the category pages


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/PLATFORM-3543
* https://github.com/Wikia/app/pull/15615

## Description

Emit surrogate keys headers defined in mediawiki. Also send an extra key with the `-mobile-wiki` suffix for purging mobile pages on a given wiki.

## Reviewers

@Wikia/core-platform-team 
FYI: @Wikia/x-wing 
