### PR TITLE
Fix dev cookie domain

### DIFF
--- a/app/instance-initializers/config.js
+++ b/app/instance-initializers/config.js
@@ -37,7 +37,9 @@ function getHeliosInfoURL(wikiaEnv, datacenter) {
 
 function getCookieDomain(wikiaEnv) {
 	if (wikiaEnv === 'dev') {
-		return `.${FastBoot.require('process').env.WIKIA_DEV_DOMAIN}`;
+		const devDomains = FastBoot.require('process').env.WIKIA_DEV_DOMAIN.split(',');
+
+		return `.${devDomains[0]}`;
 	}
 
 	return `.${config.productionBaseDomain}`;


### PR DESCRIPTION
Currently `FastBoot.require('process').env.WIKIA_DEV_DOMAIN` returns `szymon.wikia-dev.pl,szymon.fandom-dev.pl` on devbox -- setting cookie using this value does not work.