### PR TITLE
XF-573 renovate bot settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-## Overview
+[![renovate-app badge][renovate-badge]][renovate-app]
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/Wikia/mobile-wiki.svg)](https://greenkeeper.io/)
++[renovate-badge]: https://img.shields.io/badge/renovate-app-blue.svg
+[renovate-app]: https://renovateapp.com/
+
+## Overview
 Mobile Wiki is an application built on top of [Ember](https://emberjs.com/) and [Ember FastBoot](https://ember-fastboot.com/). This combination allows us serve server side rendered application to end client (The same code is executed on frontend and backend).
 
 ## Setup

--- a/package.json
+++ b/package.json
@@ -143,8 +143,15 @@
     "proxying-agent"
   ],
   "snyk": true,
-  "greenkeeper": {
-    "ignore": [
+  "renovate": {
+    "extends": [
+      "config:base"
+    ],
+    "automerge": true,
+    "major": {
+      "automerge": false
+    },
+    "ignoreDeps": [
       "ember-cli",
       "ember-source"
     ]


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/XF-573
* My test repo with renovate installed: https://github.com/jsutterfield/mobile-wiki-renovate
* An example of one of the PRs opened by renovate: https://github.com/jsutterfield/mobile-wiki-renovate/pull/7
* Renovate bot in the github market place https://github.com/marketplace/renovate
* A blog post about using renovate: https://glebbahmutov.com/blog/renovate-app/

## Description
This PR replaces the configuration for greenkeeper with the configuration for renovate bot. Renovate bot performs the same function as greenkeeper, namely keeping our npm modules up to date, but allows things like auto-merging and supports private repos.

I copied the mobile-app wiki [here](https://github.com/jsutterfield/mobile-wiki-renovate/settings) and installed renovate as a github app. AFAICT, it works just like we'd expect it to. I kept the configuration fairly standard, opting to use the default config but allow renovate to merge non-major updates, but it's pretty configurable so we could tweak this as necessary. I also configured it to ignore deps for `ember-cli` and `ember-source`, since that's what greenkeeper was doing.

## Next steps
This PR is currently marked as "DON'T MERGE!" as we'll want to deactivate greenkeeper and install renovate bot when we're ready to make the switch. 

## Reviewers
@Wikia/iris 