### PR TITLE
ADEN-7526 Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -350,34 +350,34 @@
         "long": "^3.2.0"
       }
     },
-    "@wikia/ad-engine": {
-      "version": "git+https://github.com/Wikia/ad-engine.git#afce6653dd3abcc36a8ad7a95203cfe5fd4b6cf4",
-      "from": "git+https://github.com/Wikia/ad-engine.git#v12.1.1",
+    "@wikia/ad-products": {
+      "version": "git+https://github.com/Wikia/ad-products.git#3a6eb45d6e17e2397758428aadc0f0c8f145f9e1",
+      "from": "git+https://github.com/Wikia/ad-products.git#v7.7.2",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "blockadblock": "3.2.1",
+        "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#02f08d6355110a09ce1a56e4b27a6f284e5027d4",
         "core-decorators": "^0.20.0",
-        "current-device": "0.7.8",
-        "eventemitter3": "3.0.1",
+        "events": "^1.1.1",
+        "js-cookie": "^2.1.4",
         "lodash": "^4.17.4"
       },
       "dependencies": {
+        "@wikia/ad-engine": {
+          "version": "git+https://github.com/Wikia/ad-engine.git#02f08d6355110a09ce1a56e4b27a6f284e5027d4",
+          "from": "git+https://github.com/Wikia/ad-engine.git#v12.1.2",
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "blockadblock": "3.2.1",
+            "core-decorators": "^0.20.0",
+            "current-device": "0.7.8",
+            "eventemitter3": "3.0.1",
+            "lodash": "^4.17.4"
+          }
+        },
         "eventemitter3": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.0.1.tgz",
           "integrity": "sha512-QOCPu979MMWX9XNlfRZoin+Wm+bK1SP7vv3NGUniYwuSJK/+cPA10blMaeRgzg31RvoSFk6FsCDVa4vNryBTGA=="
         }
-      }
-    },
-    "@wikia/ad-products": {
-      "version": "git+https://github.com/Wikia/ad-products.git#ee6738ded6ef36adad7ce4f71a6e3401774dea22",
-      "from": "git+https://github.com/Wikia/ad-products.git#v7.7.1",
-      "requires": {
-        "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#afce6653dd3abcc36a8ad7a95203cfe5fd4b6cf4",
-        "core-decorators": "^0.20.0",
-        "events": "^1.1.1",
-        "js-cookie": "^2.1.4",
-        "lodash": "^4.17.4"
       }
     },
     "@wikia/ember-fandom": {
@@ -11023,7 +11023,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.4",
@@ -11254,6 +11255,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@wikia/ad-products": "git+https://github.com/Wikia/ad-products.git#v7.7.1",
+    "@wikia/ad-products": "git+https://github.com/Wikia/ad-products.git#v7.7.2",
     "@wikia/tracking-opt-in": "1.0.36",
     "@wikia/ember-fandom": "Wikia/ember-fandom#7b07ef1eb7c72cb2e70bb6ed5f8bfe4eea3faa6d",
     "body-parser": "1.18.3",


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/ADEN-7526

## Description
Update `ad-products` version in order for better out-stream video on mobile-wiki (ad label and start it only when in viewport).
