### PR TITLE
Fix event-logger URL

### DIFF
--- a/app/modules/event-logger.js
+++ b/app/modules/event-logger.js
@@ -1,9 +1,9 @@
 import fetch from 'fetch';
 import config from '../config/environment';
 
-const url = `${config.APP.servicesExternalHost}/event-logger`;
-
 function logEvent(resource, name, description = {}) {
+	const url = `${config.APP.servicesExternalHost}/event-logger`;
+
 	if (config.environment === 'production') {
 		fetch(`${url}/${resource}`, {
 			method: 'POST',


### PR DESCRIPTION
## Description
`servicesExternalHost` is set in `instance-initializers/config.js` and if we try to read it in the global scope it's not defined yet.

## Reviewers
@Wikia/x-wing 