### PR TITLE
PLATFORM-3650 | Add language path to /main/edit url

### DIFF
--- a/app/components/wikia-ui-components/wiki-page-header-curated-main-page.js
+++ b/app/components/wikia-ui-components/wiki-page-header-curated-main-page.js
@@ -6,19 +6,20 @@ import { track, trackActions } from '../../utils/track';
 
 export default Component.extend(
   {
-    classNames: ['wiki-page-header-curated-main-page'],
-
     wikiUrls: service(),
     wikiVariables: service(),
+
+    classNames: ['wiki-page-header-curated-main-page'],
+
+    mainPageTitle: reads('wikiVariables.mainPageTitle'),
+    siteName: reads('wikiVariables.siteName'),
 
     mainPageEditorUrl: computed(function () {
       return this.wikiUrls.build({
         host: this.wikiVariables.host,
-        path: '/main/edit'
+        path: '/main/edit',
       });
     }),
-    mainPageTitle: reads('wikiVariables.mainPageTitle'),
-    siteName: reads('wikiVariables.siteName'),
 
     actions: {
       trackClick(trackingLabel) {

--- a/app/components/wikia-ui-components/wiki-page-header-curated-main-page.js
+++ b/app/components/wikia-ui-components/wiki-page-header-curated-main-page.js
@@ -1,14 +1,24 @@
 import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
 import { reads } from '@ember/object/computed';
 import Component from '@ember/component';
 import { track, trackActions } from '../../utils/track';
 
 export default Component.extend(
   {
-    wikiVariables: service(),
     classNames: ['wiki-page-header-curated-main-page'],
-    siteName: reads('wikiVariables.siteName'),
+
+    wikiUrls: service(),
+    wikiVariables: service(),
+
+    mainPageEditorUrl: computed(function () {
+      return this.wikiUrls.build({
+        host: this.wikiVariables.host,
+        path: '/main/edit'
+      });
+    }),
     mainPageTitle: reads('wikiVariables.mainPageTitle'),
+    siteName: reads('wikiVariables.siteName'),
 
     actions: {
       trackClick(trackingLabel) {

--- a/app/templates/components/wikia-ui-components/wiki-page-header-curated-main-page.hbs
+++ b/app/templates/components/wikia-ui-components/wiki-page-header-curated-main-page.hbs
@@ -2,7 +2,7 @@
   {{title}}
   {{#if showButtons}}
     <div>
-      <a href="/main/edit" class="main-page-edit wds-font-size-s wds-font-weight-normal wds-text-transform-none" {{action 'trackClick' 'open-editor' preventDefault=false}}>
+      <a href="{{mainPageEditorUrl}}" class="main-page-edit wds-font-size-s wds-font-weight-normal wds-text-transform-none" {{action 'trackClick' 'open-editor' preventDefault=false}}>
         {{svg 'wds-icons-pencil-small' role='img' class='wds-icon wds-icon-small'}}
         {{i18n 'app.curated-content-editor-edit-main-page'}}
       </a>


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/PLATFORM-3650

## Description

`wikiUrls.buildUrl()` already handles language paths. Let's use it.

## Reviewers

@Wikia/x-wing @Wikia/core-platform-team 