### PR TITLE
XF-53 | use defaults from eslint-plugin-ember

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,7 @@
+const {
+  DEFAULT_IGNORED_PROPERTIES
+}= require('eslint-plugin-ember/lib/rules/avoid-leaking-state-in-ember-objects');
+
 module.exports = {
   root: true,
   parserOptions: {
@@ -42,21 +46,13 @@ module.exports = {
     "strict": 0,
 
     "ember/avoid-leaking-state-in-ember-objects": [2, [
+      ...DEFAULT_IGNORED_PROPERTIES,
       'gestures',
-      'classNames',
-      'classNameBindings',
-      'actions',
-      'concatenatedProperties',
-      'mergedProperties',
-      'positionalParams',
-      'attributeBindings',
-      'queryParams',
-      'attrs'
     ]],
     "ember/no-jquery": 2,
-    "ember/order-in-components": 1,
-    "ember/order-in-controllers": 1,
-    "ember/order-in-routes": 1
+    "ember/order-in-components": 2,
+    "ember/order-in-controllers": 2,
+    "ember/order-in-routes": 2
   },
   overrides: [
     // node files

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 const {
   DEFAULT_IGNORED_PROPERTIES
-}= require('eslint-plugin-ember/lib/rules/avoid-leaking-state-in-ember-objects');
+} = require('eslint-plugin-ember/lib/rules/avoid-leaking-state-in-ember-objects');
 
 module.exports = {
   root: true,


### PR DESCRIPTION
This way we don't have to keep it in sync with eslint-plugin-ember

also since we do keep order in files let's treat is an error