### PR TITLE
Move base meta tags to index.html so they work on error pages

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1, minimal-ui, viewport-fit=cover">
 <meta name="theme-color" content="#002a32">
 <link rel="preconnect" href="https://vignette.wikia.nocookie.net">
-{{! fallback to dns-prefetch for iOS where preconnect isn't supported yet}}
+<!-- fallback to dns-prefetch for iOS where preconnect isn't supported yet -->
 <link rel="dns-prefetch" href="https://vignette.wikia.nocookie.net">
 
 <link rel="stylesheet" href="/mobile-wiki-assets/assets/app.css">

--- a/app/index.html
+++ b/app/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1, minimal-ui, viewport-fit=cover">
+<meta name="theme-color" content="#002a32">
+<link rel="preconnect" href="https://vignette.wikia.nocookie.net">
+{{! fallback to dns-prefetch for iOS where preconnect isn't supported yet}}
+<link rel="dns-prefetch" href="https://vignette.wikia.nocookie.net">
+
 <link rel="stylesheet" href="/mobile-wiki-assets/assets/app.css">
 <script src="/mobile-wiki-assets/assets/vendor.js" defer></script>
 <script src="/mobile-wiki-assets/assets/mobile-wiki.js" defer></script>

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -1,14 +1,4 @@
 {{! Tags set once (static head tags) }}
-<meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1, minimal-ui, viewport-fit=cover">
-
-<meta name="theme-color" content="#002a32">
-
-<link rel="preconnect" href="https://vignette.wikia.nocookie.net">
-{{! fallback to dns-prefetch for iOS where preconnect isn't supported yet}}
-<link rel="dns-prefetch" href="https://vignette.wikia.nocookie.net">
-
 {{#unless model.noExternals}}
   <link rel="dns-prefetch" href="http://edge.quantserve.com">
   <link rel="dns-prefetch" href="http://secure-dcr.imrworldwide.com/">

--- a/tests/acceptance/head-tags-test.js
+++ b/tests/acceptance/head-tags-test.js
@@ -12,22 +12,6 @@ module('Acceptance | Head meta tags', (hooks) => {
     mockAdsService(this.owner);
   });
 
-  test('check basic meta tags', async (assert) => {
-    await visit('/');
-
-    /* This is a bit hacky,
-    but test runs do not have their own 'head' that is why We have to test if a test run
-    set something in head of a test runner document */
-    assert.equal(
-      document.querySelectorAll('meta[name="viewport"]')[1].getAttribute('content'),
-      'user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1, minimal-ui, viewport-fit=cover',
-    );
-    assert.equal(
-      document.querySelector('meta[name="theme-color"]').getAttribute('content'),
-      '#002a32',
-    );
-  });
-
   test('check twitter meta tags', async (assert) => {
     await visit('/wiki/File:Example.jpg');
 


### PR DESCRIPTION
## Description

An application error (e.g. https://maelstrom.wikia.com/wiki/Main_Page) looks bad on mobile because for some reason we don't render `head.hbs` when there is an application error. This is a quick, easy fix. There is no advantage in keeping those meta tags in `head.hbs` anyway.

## Reviewers

@Wikia/x-wing