### PR TITLE
(MAIN-17480) Add missing inclusion of runtime-config service

### DIFF
--- a/app/components/global-footer/global-footer-bottom-bar.js
+++ b/app/components/global-footer/global-footer-bottom-bar.js
@@ -2,6 +2,7 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 
 export default Component.extend({
+  runtimeConfig: service(),
   wikiVariables: service(),
 
   tagName: '',


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/MAIN-17480
* https://github.com/Wikia/mobile-wiki/pull/1010

## Description

Add missing inclusion of runtime-config service. This was causing the error:

    Uncaught TypeError: Cannot read property 'cookieDomain' of undefined

## Reviewers

@Wikia/x-wing @rybmat @hakubo 
