### PR TITLE
OPS-12119: X-Surrogate-Key header cleanup

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -172,7 +172,6 @@ export default Route.extend(
           // append mobile-wiki specific key
           surrogateKey = `${surrogateKey} ${surrogateKey}-mobile-wiki`;
           fastboot.get('response.headers').set('Surrogate-Key', surrogateKey);
-          fastboot.get('response.headers').set('X-Surrogate-Key', surrogateKey);
         }
 
         // TODO remove `transition.queryParams.page`when icache supports surrogate keys


### PR DESCRIPTION
## Description
`X-Surrogate-Key` - Fastly doesn't support such header (they use `Surrogate-Key`. We want to cleanup this custom header (it's not used by our caches).