### PR TITLE
IW-1283 | Delay smartbanner until we know UAP will not show up

### DIFF
--- a/app/services/smart-banner.js
+++ b/app/services/smart-banner.js
@@ -1,13 +1,13 @@
-import {computed} from '@ember/object';
+import { computed } from '@ember/object';
 import {
   and,
   equal,
   readOnly,
   or,
 } from '@ember/object/computed';
-import Service, {inject as service} from '@ember/service';
-import {track} from '../utils/track';
-import {system} from '../utils/browser';
+import Service, { inject as service } from '@ember/service';
+import { track } from '../utils/track';
+import { system } from '../utils/browser';
 import getAdsModule from '../modules/ads';
 
 export default Service.extend({
@@ -35,7 +35,8 @@ export default Service.extend({
         && this.smartBannerVisible
         && !this.isCustomSmartBannerVisible
         && this.willUapNotAppear;
-    }),
+    },
+  ),
 
   isCustomSmartBannerVisible: and(
     'shouldShowFandomAppSmartBanner',

--- a/app/services/smart-banner.js
+++ b/app/services/smart-banner.js
@@ -37,6 +37,8 @@ export default Service.extend({
   ),
 
   init() {
+    this._super(...arguments);
+
     getAdsModule()
     // Use noUap callback to allow SmartBanner to show up. This prevents SB from showing up too soon
     // and then being replaced by UAP

--- a/app/services/smart-banner.js
+++ b/app/services/smart-banner.js
@@ -1,13 +1,13 @@
-import { computed } from '@ember/object';
+import {computed} from '@ember/object';
 import {
   and,
   equal,
   readOnly,
   or,
 } from '@ember/object/computed';
-import Service, { inject as service } from '@ember/service';
-import { track } from '../utils/track';
-import { system } from '../utils/browser';
+import Service, {inject as service} from '@ember/service';
+import {track} from '../utils/track';
+import {system} from '../utils/browser';
 import getAdsModule from '../modules/ads';
 
 export default Service.extend({
@@ -26,12 +26,16 @@ export default Service.extend({
   smartBannerAdConfiguration: readOnly('wikiVariables.smartBannerAdConfiguration'),
   isUserLangEn: equal('currentUser.language', 'en'),
   shouldShowFandomAppSmartBanner: and('isUserLangEn', 'wikiVariables.enableFandomAppSmartBanner'),
-  isFandomAppSmartBannerVisible: computed('shouldShowFandomAppSmartBanner', 'smartBannerVisible', function () {
-    return this.shouldShowFandomAppSmartBanner
-      && this.smartBannerVisible
-      && !this.isCustomSmartBannerVisible
-      && this.willUapNotAppear;
-  }),
+  isFandomAppSmartBannerVisible: computed(
+    'shouldShowFandomAppSmartBanner',
+    'smartBannerVisible',
+    'willUapNotAppear',
+    function () {
+      return this.shouldShowFandomAppSmartBanner
+        && this.smartBannerVisible
+        && !this.isCustomSmartBannerVisible
+        && this.willUapNotAppear;
+    }),
 
   isCustomSmartBannerVisible: and(
     'shouldShowFandomAppSmartBanner',
@@ -48,7 +52,8 @@ export default Service.extend({
     getAdsModule()
     // Use noUap callback to allow SmartBanner to show up. This prevents SB from showing up too soon
     // and then being replaced by UAP
-      .then(adsModule => adsModule.waitForUapResponse(() => {}, () => {
+      .then(adsModule => adsModule.waitForUapResponse(() => {
+      }, () => {
         this.set('willUapNotAppearForAnon', true);
       }));
   },

--- a/app/services/smart-banner.js
+++ b/app/services/smart-banner.js
@@ -1,5 +1,10 @@
 import { computed } from '@ember/object';
-import { and, equal, readOnly, or } from '@ember/object/computed';
+import {
+  and,
+  equal,
+  readOnly,
+  or,
+} from '@ember/object/computed';
 import Service, { inject as service } from '@ember/service';
 import { track } from '../utils/track';
 import { system } from '../utils/browser';

--- a/app/services/smart-banner.js
+++ b/app/services/smart-banner.js
@@ -1,5 +1,5 @@
 import { computed } from '@ember/object';
-import { and, equal, readOnly } from '@ember/object/computed';
+import { and, equal, readOnly, or } from '@ember/object/computed';
 import Service, { inject as service } from '@ember/service';
 import { track } from '../utils/track';
 import { system } from '../utils/browser';
@@ -14,7 +14,8 @@ export default Service.extend({
   dayInMiliseconds: 86400000,
   fandomAppCookieName: 'fandom-sb-closed',
   customCookieName: 'custom-sb-closed',
-  willUapNotAppear: false,
+  willUapNotAppearForAnon: false,
+  willUapNotAppear: or('currentUser.isAuthenticated', 'willUapNotAppearForAnon'),
 
   dbName: readOnly('wikiVariables.dbName'),
   smartBannerAdConfiguration: readOnly('wikiVariables.smartBannerAdConfiguration'),
@@ -43,7 +44,7 @@ export default Service.extend({
     // Use noUap callback to allow SmartBanner to show up. This prevents SB from showing up too soon
     // and then being replaced by UAP
       .then(adsModule => adsModule.waitForUapResponse(() => {}, () => {
-        this.set('willUapNotAppear', true);
+        this.set('willUapNotAppearForAnon', true);
       }));
   },
 


### PR DESCRIPTION
@Wikia/iwing @Wikia/adeng 

The change:

We want to wait until we know for sure that UAP will not show up before showing SmartBanner to avoid a situation where SmartBanner shows up and then it's being hidden for UAP to show (content jumping).