### PR TITLE
Revert "Use custom workspace on QA executors and cleanup"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,6 @@
 pipeline {
   agent {
-    label {
-            label 'qa-executors'
-            customWorkspace "var/lib/jenkins/workspace/mobile-wiki-pr-checks_2_EXECUTOR${env.EXECUTOR_NUMBER}"
-        }
+    label 'qa-executors'
   }
 
   stages {
@@ -61,11 +58,6 @@ pipeline {
         methodCoverageTargets: '80, 0, 0',
         onlyStable: false,
         zoomCoverageChart: false
-    }
-    cleanup {
-        dir('node_modules') {
-          deleteDir()
-      }
     }
   }
 }


### PR DESCRIPTION
Reverts Wikia/mobile-wiki#1274 caus of executor_number var being resolved to null like:
`git init /var/lib/jenkins/var/lib/jenkins/workspace/mobile-wiki-pr-checks_2_EXECUTORnull # timeout=10`