### PR TITLE
XF-38 | add mobile-wiki to services dashboard

### DIFF
--- a/services-dashboard.json
+++ b/services-dashboard.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "mobile-wiki",
+    "owner": {
+      "team": "i-wing",
+      "slack": "#iwing",
+      "e-mail": "iwing@wikia-inc.com"
+    },
+    "contributors": [
+    ],
+    "dashboards": [
+      "https://metrics.wikia-inc.com/d/000000192/mobilewiki-k8s?refresh=1m&orgId=1",
+      "https://metrics.wikia-inc.com/d/000000167/traefik-apdex?refresh=10s"
+    ],
+    "documentation": [
+      "https://github.com/Wikia/mobile-wiki/blob/dev/README.md"
+    ],
+    "other-links": [],
+    "rabbit-queues": []
+  }
+]


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/XF-38
* https://wikia-inc.atlassian.net/wiki/spaces/PLAT/pages/178946053/How+to+add+a+service+to+Services+Dashboard
* http://services-dashboard.sjc.k8s.wikia.net/services-dashboard

## Description

Adding config needed for services dashboard

## Reviewers

@Wikia/iwing 
