### PR TITLE
XF-278 | Don't fetch unnecessary user info from MW API

### DIFF
--- a/app/models/user.js
+++ b/app/models/user.js
@@ -137,7 +137,7 @@ export default EmberObject.extend({
       query: {
         action: 'query',
         meta: 'userinfo',
-        uiprop: 'rights|options|blockinfo',
+        uiprop: 'rights',
         format: 'json',
         ids: userId,
       },


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/XF-278

## Description
We use MW API to get user's rights. However, we also fetch block info and user options, without ever using that data, which triggers redundant operations such as Phalanx checks. We should only load what we need—the user's rights.
