### PR TITLE
IW-1311 | pause vid on 'X' click

### DIFF
--- a/app/components/article-featured-video.js
+++ b/app/components/article-featured-video.js
@@ -96,6 +96,7 @@ export default Component.extend(JWPlayerMixin, RespondsToScroll, {
 
       if (this.player) {
         this.player.setMute(true);
+        this.player.pause();
       }
       document.body.classList.remove(this.bodyOnScrollActiveClass);
 

--- a/app/modules/video-players/jwplayer.js
+++ b/app/modules/video-players/jwplayer.js
@@ -16,8 +16,9 @@ export default class JWPlayer extends BasePlayer {
 
     params.onCreate = (player) => {
       M.trackingQueue.push(() => {
+        originalOnCreate(player);
+
         if (this.videoAds) {
-          originalOnCreate(player);
           this.videoAds.register(player, this.getSlotTargeting());
         }
       });


### PR DESCRIPTION
## Links
* http://wikia-inc.atlassian.net/browse/IW-1311

## Description
When a user dismissed a video in `onScroll` module, it continued to play in the background, so every time next suggested video was played, the page was scrolled to top.

## Reviewers
@Wikia/iwing 
