### PR TITLE
ADEN-8335 Update ad-engine (49e4cb1886290e79fb540907fa717a7273aef009)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1428,8 +1428,8 @@
       }
     },
     "@wikia/ad-engine": {
-      "version": "git+https://github.com/Wikia/ad-engine.git#49e4cb1886290e79fb540907fa717a7273aef009",
-      "from": "git+https://github.com/Wikia/ad-engine.git#49e4cb1886290e79fb540907fa717a7273aef009",
+      "version": "git+https://github.com/Wikia/ad-engine.git#05f3c516de6bdee902a614e50c65739ec9abd84b",
+      "from": "git+https://github.com/Wikia/ad-engine.git#v23.12.2",
       "requires": {
         "babel-runtime": "6.26.0",
         "blockadblock": "3.2.1",
@@ -9605,7 +9605,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10020,7 +10021,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": false,
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10076,6 +10078,7 @@
           "version": "3.0.1",
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10119,12 +10122,14 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1428,8 +1428,8 @@
       }
     },
     "@wikia/ad-engine": {
-      "version": "git+https://github.com/Wikia/ad-engine.git#cde92b906f203e85ff473f8c151cc6382aadbaaf",
-      "from": "git+https://github.com/Wikia/ad-engine.git#v23.10.0",
+      "version": "git+https://github.com/Wikia/ad-engine.git#49e4cb1886290e79fb540907fa717a7273aef009",
+      "from": "git+https://github.com/Wikia/ad-engine.git#49e4cb1886290e79fb540907fa717a7273aef009",
       "requires": {
         "babel-runtime": "6.26.0",
         "blockadblock": "3.2.1",
@@ -9626,12 +9626,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9646,17 +9648,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9773,7 +9778,8 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": false,
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9785,6 +9791,7 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9799,6 +9806,7 @@
           "version": "3.0.4",
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9806,12 +9814,14 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": false,
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9830,6 +9840,7 @@
           "version": "0.5.1",
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9910,7 +9921,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9922,6 +9934,7 @@
           "version": "1.4.0",
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10043,6 +10056,7 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@wikia/search-tracking": "github:Wikia/search-tracking#1.0",
-    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v23.10.0",
+    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#49e4cb1886290e79fb540907fa717a7273aef009",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#9bea3e78d23804dae08322601ae0c16b3bc2149a",
     "@wikia/tracking-opt-in": "1.0.41",
     "body-parser": "1.18.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@wikia/search-tracking": "github:Wikia/search-tracking#1.0",
-    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#49e4cb1886290e79fb540907fa717a7273aef009",
+    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v23.12.2",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#9bea3e78d23804dae08322601ae0c16b3bc2149a",
     "@wikia/tracking-opt-in": "1.0.41",
     "body-parser": "1.18.3",


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/ADEN-8356

`v23.12.2` of ad-engine should help us fix performance of outstream ads