### PR TITLE
ads ref param fix: updating wiki domains

### DIFF
--- a/app/modules/ads/targeting.js
+++ b/app/modules/ads/targeting.js
@@ -101,8 +101,8 @@ function getRefParam() {
   const ref = document.referrer;
   const searchDomains = /(google|search\.yahooo|bing|baidu|ask|yandex)/;
   const wikiDomains = [
-    'wikia.com', 'ffxiclopedia.org', 'jedipedia.de',
-    'memory-alpha.org', 'uncyclopedia.org',
+    'wikia.com', 'fandom.com', 'wikia.org', 'ffxiclopedia.org',
+    'jedipedia.de', 'memory-alpha.org', 'uncyclopedia.org',
     'websitewiki.de', 'wowwiki.com', 'yoyowiki.org',
   ];
   const wikiDomainsRegex = new RegExp(`(^|\\.)(${wikiDomains.join('|').replace(/\./g, '\\.')})$`);


### PR DESCRIPTION
## Description

Making sure `fandom.com` and `wikia.org` is handled properly when setting ads `ref` param value.

## Reviewers

@Wikia/adeng 
