### PR TITLE
PLATFORM-3967: Show wikia.org migration banner

### DIFF
--- a/app/mixins/wiki-page-handler.js
+++ b/app/mixins/wiki-page-handler.js
@@ -46,7 +46,6 @@ function getURL(wikiUrls, params) {
   // this is pseudo-versioning query param for collapsible sections (XW-4393)
   // should be removed after all App caches are invalidated
   query.collapsibleSections = 1;
-console.log("===============================================",query);
   return wikiUrls.build({
     host: params.host,
     forceNoSSLOnServerSide: true,

--- a/app/mixins/wiki-page-handler.js
+++ b/app/mixins/wiki-page-handler.js
@@ -46,7 +46,7 @@ function getURL(wikiUrls, params) {
   // this is pseudo-versioning query param for collapsible sections (XW-4393)
   // should be removed after all App caches are invalidated
   query.collapsibleSections = 1;
-
+console.log("===============================================",query);
   return wikiUrls.build({
     host: params.host,
     forceNoSSLOnServerSide: true,

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -26,6 +26,7 @@ export default Route.extend(
     ads: service('ads/ads'),
     currentUser: service(),
     fandomComMigration: service(),
+    wikiaOrgMigration: service(),
     fastboot: service(),
     i18n: service(),
     lightbox: service(),
@@ -146,6 +147,7 @@ export default Route.extend(
       }
 
       this.fandomComMigration.showNotification();
+      this.wikiaOrgMigration.showNotification();
     },
 
     redirect(model) {

--- a/app/services/wikia-org-migration.js
+++ b/app/services/wikia-org-migration.js
@@ -1,0 +1,68 @@
+import Service, { inject as service } from '@ember/service';
+import localStorageConnector from '@wikia/ember-fandom/utils/local-storage-connector';
+
+export default Service.extend({
+  fastboot: service(),
+  wdsBannerNotifications: service(),
+  wikiVariables: service(),
+
+  afterMigrationClosedStorageKey: 'wikia-org-migration-after-closed',
+  beforeMigrationClosedStorageKey: 'wikia-org-migration-before-closed',
+  storageTrueValue: '1',
+  // Keep it for a year, it's more than enough
+  localStorageTTL: 60 * 60 * 24 * 365,
+
+  shouldShowAfterMigrationNotification() {
+    return this.wikiVariables.wikiaOrgMigrationNotificationAfter
+      && localStorageConnector.getItem(
+        this.afterMigrationClosedStorageKey,
+      ) !== this.storageTrueValue;
+  },
+
+  shouldShowBeforeMigrationNotification() {
+    return this.wikiVariables.wikiaOrgMigrationNotificationBefore
+      && localStorageConnector.getItem(
+        this.beforeMigrationClosedStorageKey,
+      ) !== this.storageTrueValue;
+  },
+
+  showAfterMigrationNotification() {
+    this.wdsBannerNotifications.addNotification({
+      type: 'warning',
+      alreadySafeHtml: this.wikiVariables.wikiaOrgMigrationNotificationAfter,
+      disableAutoHide: true,
+      onClose: () => {
+        localStorageConnector.setItem(
+          this.afterMigrationClosedStorageKey,
+          this.storageTrueValue,
+        );
+      },
+    });
+  },
+
+  showBeforeMigrationNotification() {
+    this.wdsBannerNotifications.addNotification({
+      type: 'warning',
+      alreadySafeHtml: this.wikiVariables.wikiaOrgMigrationNotificationBefore,
+      disableAutoHide: true,
+      onClose: () => {
+        localStorageConnector.setItem(
+          this.beforeMigrationClosedStorageKey,
+          this.storageTrueValue,
+        );
+      },
+    });
+  },
+
+  showNotification() {
+    if (this.fastboot.isFastBoot) {
+      return;
+    }
+
+    if (this.shouldShowAfterMigrationNotification()) {
+      this.showAfterMigrationNotification();
+    } else if (this.shouldShowBeforeMigrationNotification()) {
+      this.showBeforeMigrationNotification();
+    }
+  },
+});


### PR DESCRIPTION
## Description
Enable messages about wikia.org migration. You need to set up flags to enable messages. Set wgWikiaOrgMigrationScheduled' or wgWikiaOrgMigrationDone to see standard message. Similar to fandom.com migration messages

