### PR TITLE
Remove step timeout for npm install, disable npm console printing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
   stages {
     stage('npm ci') {
       options {
-        timeout(time: 10, unit: 'MINUTES')
+        timeout(time: 15, unit: 'MINUTES')
       }
       steps {
         sh 'npm install'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,9 +5,6 @@ pipeline {
 
   stages {
     stage('npm ci') {
-      options {
-        timeout(time: 15, unit: 'MINUTES')
-      }
       steps {
         sh 'npm set progress=false'
         sh 'npm install'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
         timeout(time: 15, unit: 'MINUTES')
       }
       steps {
+        sh 'npm set progress=false'
         sh 'npm install'
       }
     }

--- a/Jenkinsfile-build-and-deploy
+++ b/Jenkinsfile-build-and-deploy
@@ -91,3 +91,6 @@ node('docker-daemon') {
         }
     }
 }
+
+
+

--- a/Jenkinsfile-build-and-deploy
+++ b/Jenkinsfile-build-and-deploy
@@ -91,6 +91,3 @@ node('docker-daemon') {
         }
     }
 }
-
-
-


### PR DESCRIPTION
* Remove timeout option for `npm install` step. It will use globally (per Jenkins) configured timeouts for a whole job
* Speed up the process by disabling printing from `npm` commands