### PR TITLE
IW-1851 | Do not add collapsibleSections param to Mediawiki request

### DIFF
--- a/app/mixins/wiki-page-handler.js
+++ b/app/mixins/wiki-page-handler.js
@@ -43,9 +43,6 @@ function getURL(wikiUrls, params) {
     query.categoryMembersFrom = params.from;
   }
 
-  // this is pseudo-versioning query param for collapsible sections (XW-4393)
-  // should be removed after all App caches are invalidated
-  query.collapsibleSections = 1;
   return wikiUrls.build({
     host: params.host,
     forceNoSSLOnServerSide: true,

--- a/config/bundlesize.js
+++ b/config/bundlesize.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   'app.css': {
     pattern: `${assetsFolder}/app.css`,
-    limit: '92KB',
+    limit: '100KB',
   },
   'lazy.css': {
     pattern: `${assetsFolder}/lazy-*.css`,


### PR DESCRIPTION
@Wikia/iwing 

This param causes us problems when purging iCache. We do not use collapsed sections in mobile-wiki anymore (confirmed by @Wikia/adeng) - we're safe to remove it. https://wikia-inc.atlassian.net/browse/IW-1905 -> Mediawiki cleanup ticket.