### PR TITLE
Use custom workspace path and explicit node declaration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,10 @@
 pipeline {
   agent {
-    label 'qa-executors'
+    node {
+        label 'qa-executors'
+        customWorkspace "/var/lib/jenkins/workspace/mobile-wiki-pr-checks-2-${BRANCH_NAME}"
+
+    }
   }
 
   stages {


### PR DESCRIPTION
Same story as recently in the design-system. Workspace path for this job were cut off and `npm` commands could not be executed properly, since they had wrong context.