### PR TITLE
ADEN-8820 Reset BTL refresh counter

### DIFF
--- a/app/modules/ads/bill-the-lizard-wrapper.js
+++ b/app/modules/ads/bill-the-lizard-wrapper.js
@@ -13,6 +13,7 @@ let cheshirecatCalled = false;
 let initialValueOfIncontentsCounter = 1;
 let incontentsCounter = initialValueOfIncontentsCounter;
 let defaultStatus = NOT_USED_STATUS;
+let refreshedSlotNumber = null;
 
 function getCallId(counter = null) {
   const { context } = window.Wikia.adEngine;
@@ -97,7 +98,6 @@ export const billTheLizardWrapper = {
       context, events, eventService, slotService, utils,
     } = window.Wikia.adEngine;
     const { billTheLizard, BillTheLizard, billTheLizardEvents } = window.Wikia.adServices;
-    let refreshedSlotNumber;
     let baseSlotName = 'incontent_boxad_1';
     defaultStatus = NOT_USED_STATUS;
 
@@ -231,6 +231,7 @@ export const billTheLizardWrapper = {
     cheshirecatCalled = false;
     incontentsCounter = initialValueOfIncontentsCounter;
     defaultStatus = NOT_USED_STATUS;
+    refreshedSlotNumber = null;
 
     // Reset predictions from previous page views
     billTheLizard.reset();


### PR DESCRIPTION
`refreshedSlotNumber` counter wasn't reset between consecutive pvs. Because of that it was triggering bill call after bids refresh no matter if it was the first slot or not:
https://github.com/Wikia/mobile-wiki/pull/1577/files#diff-f78dc433a1ba06807de469d1883a068bR144
Having that it was possible that first call of bill executed `on_1` (`catlapseIncontentBoxad`) on `top_boxad`.

## Links

* http://wikia-inc.atlassian.net/browse/ADEN-8820