### PR TITLE
IW | bring back assetMap.json to the dist

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -66,6 +66,7 @@ module.exports = function (defaults) {
       remove: false,
     },
     fingerprint: {
+      generateAssetMap: true,
       exclude: ['app.css'],
       extensions: ['js', 'css', 'svg', 'png', 'jpg', 'gif', 'map'],
       replaceExtensions: ['html', 'css', 'js', 'hbs'],


### PR DESCRIPTION
## Description
looks like at some point (probably after updating of broccoli-asset-rev lib) assetMap.json file stopped to be generated. That results in vendorj.js file not being preloaded by browser https://github.com/Wikia/mobile-wiki/blob/36519d51e46f1219510ed1d801f83862ab6dbf73/fastboot-server/headers.js#L29-L38 and therefore performance of page was degraded.

## Reviewers

@Wikia/iwing 
@themech 
