### PR TITLE
CAKE-5055 Upgrade tracking-opt-in package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2037,9 +2037,9 @@
       }
     },
     "@wikia/tracking-opt-in": {
-      "version": "1.0.41",
-      "resolved": "https://artifactory.wikia-inc.com:443/artifactory/api/npm/wikia-npm/@wikia/tracking-opt-in/-/tracking-opt-in-1.0.41.tgz",
-      "integrity": "sha1-rkPJIIXZLV9T+NfmQdqD8IyFkWg="
+      "version": "2.0.2",
+      "resolved": "https://artifactory.wikia-inc.com:443/artifactory/api/npm/wikia-npm/@wikia/tracking-opt-in/-/tracking-opt-in-2.0.2.tgz",
+      "integrity": "sha1-EGx1K/+7Qx1sxmO3S3Mf4+Qk+V8="
     },
     "@xg-wang/whatwg-fetch": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v41.7.0",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#659888c2d5466ccc0db17e42e69f17cb2d6cd7d2",
     "@wikia/search-tracking": "github:Wikia/search-tracking#1.2.0",
-    "@wikia/tracking-opt-in": "1.0.41",
+    "@wikia/tracking-opt-in": "2.0.2",
     "body-parser": "1.19.0",
     "bunyan-prettystream": "0.1.3",
     "compression": "1.7.4",


### PR DESCRIPTION
## Links
* http://wikia-inc.atlassian.net/browse/CAKE-5055

## Description
Update tracking-opt-in (GDPR dialog) to the new two-screen version. Currently deployed to sandbox-s5.

@Wikia/cake 