### PR TITLE
Fix package-lock.json dep bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2030,8 +2030,8 @@
       }
     },
     "@wikia/search-tracking": {
-      "version": "github:Wikia/search-tracking#150b35b6eeda25aef65caf1c19cc8b8bf6621063",
-      "from": "github:Wikia/search-tracking#1.2.0",
+      "version": "github:Wikia/search-tracking#d8ee299dbb7d49b46b048e74d3d87fde0fb54779",
+      "from": "github:Wikia/search-tracking#2.0.0",
       "requires": {
         "js-cookie": "2.2.0"
       }


### PR DESCRIPTION
The `package.json` update from https://github.com/Wikia/mobile-wiki/pull/1762 lacked `package-lock.json` update.

Ping @Wikia/iwing @kejwmen @slayful 