### PR TITLE
CAKE-5177 | As a staff, I'd like to manage targeting for each affiliate unit

### DIFF
--- a/app/components/post-search-results.js
+++ b/app/components/post-search-results.js
@@ -46,6 +46,7 @@ export default Component.extend({
   fetchService: service('fetch'),
   logger: service(),
   wikiVariables: service(),
+  affiliateSlots: service(),
 
   isLoading: true,
   isCrossWiki: false,
@@ -54,6 +55,11 @@ export default Component.extend({
   // TODO: Use when releasing search for all post types
   // seeMoreButtonEnabled: not('isCrossWiki'),
   seeMoreButtonEnabled: false,
+
+  // FIXME: Remove when doing CAKE-5174
+  affiliateUnit: computed('query', function () {
+    return this.affiliateSlots.getUnitOnSearch(this.get('query'));
+  }),
 
   // fortunately we can compute the feeds path from articlePath (it has lang part)
   seeMoreUrl: computed('wikiVariables.articlePath', function () {

--- a/app/components/post-search-results.js
+++ b/app/components/post-search-results.js
@@ -56,7 +56,6 @@ export default Component.extend({
   // seeMoreButtonEnabled: not('isCrossWiki'),
   seeMoreButtonEnabled: false,
 
-  // FIXME: Remove when doing CAKE-5174
   affiliateUnit: computed('query', function () {
     return this.affiliateSlots.getUnitOnSearch(this.get('query'));
   }),

--- a/app/services/affiliate-slots-targeting.json
+++ b/app/services/affiliate-slots-targeting.json
@@ -1,14 +1,16 @@
 [
   {
-    "comment": "Fandom.com test for keiko-test wiki",
+    "comment": "Fandom.com test for keiko-test wiki on prod and on muppet on dev on searching for 'coffee'",
     "unit": "fandom-com",
     "wikiId": [
+      1081891,
+      831
     ],
     "country": [
     ],
-    "page": [
-    ],
+    "page": false,
     "query": [
+      "coffee"
     ],
     "vertical": [
     ]

--- a/app/services/affiliate-slots-targeting.json
+++ b/app/services/affiliate-slots-targeting.json
@@ -1,0 +1,16 @@
+[
+  {
+    "comment": "Fandom.com test for keiko-test wiki",
+    "unit": "fandom-com",
+    "wikiId": [
+    ],
+    "country": [
+    ],
+    "page": [
+    ],
+    "query": [
+    ],
+    "vertical": [
+    ]
+  }
+]

--- a/app/services/affiliate-slots-targeting.json
+++ b/app/services/affiliate-slots-targeting.json
@@ -1,7 +1,10 @@
 [
   {
     "comment": "Fandom.com test for keiko-test wiki on prod and on muppet on dev on searching for 'coffee'",
-    "unit": "fandom-com",
+    "unit": [
+      "fandom-com",
+      "fandom-com2"
+    ],
     "wikiId": [
       1081891,
       831
@@ -13,6 +16,20 @@
       "coffee"
     ],
     "vertical": [
+    ]
+  },
+  {
+    "comment": "Fandom.com 2 test for keiko-test wiki on prod and on muppet on dev on searching for 'foo'",
+    "unit": [
+      "fandom-com2"
+    ],
+    "wikiId": [
+      1081891,
+      831
+    ],
+    "page": false,
+    "query": [
+      "foo"
     ]
   }
 ]

--- a/app/services/affiliate-slots-targeting.json
+++ b/app/services/affiliate-slots-targeting.json
@@ -1,13 +1,12 @@
 [
   {
-    "comment": "Fandom.com test for keiko-test wiki on prod and on muppet on dev on searching for 'coffee'",
+    "comment": "Fandom.com test for keiko-test wiki on searching for 'coffee'",
     "unit": [
       "fandom-com",
       "fandom-com2"
     ],
     "wikiId": [
-      1081891,
-      831
+      1081891
     ],
     "country": [
     ],
@@ -19,13 +18,12 @@
     ]
   },
   {
-    "comment": "Fandom.com 2 test for keiko-test wiki on prod and on muppet on dev on searching for 'foo'",
+    "comment": "Fandom.com 2 test for keiko-test wiki on dev on searching for 'foo'",
     "unit": [
       "fandom-com2"
     ],
     "wikiId": [
-      1081891,
-      831
+      1081891
     ],
     "page": false,
     "query": [

--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -5,5 +5,12 @@
     "heading": "Fandom",
     "subheading": "Check this out",
     "link": "https://fandom.com"
+  },
+  {
+    "name": "fandom-com2",
+    "image": "https://vignette.wikia.nocookie.net/central/images/b/bc/Wiki.png/revision/latest?cb=20180423162614",
+    "heading": "Wikia",
+    "subheading": "Ye old times",
+    "link": "https://fandom.com"
   }
 ]

--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "fandom-com",
+    "image": "https://vignette.wikia.nocookie.net/central/images/b/bc/Wiki.png/revision/latest?cb=20180423162614",
+    "heading": "Fandom",
+    "subheading": "Check this out",
+    "link": "https://fandom.com"
+  }
+]

--- a/app/services/affiliate-slots.js
+++ b/app/services/affiliate-slots.js
@@ -1,0 +1,89 @@
+import {
+  readOnly,
+} from '@ember/object/computed';
+import Service, { inject as service } from '@ember/service';
+
+import targeting from './affiliate-slots-targeting.json';
+import units from './affiliate-slots-units.json';
+
+/**
+ *  Returns `true` if filter is undefined OR if it has the value
+ */
+function checkFilter(filter, value) {
+  return typeof filter === 'undefined'
+    || (Array.isArray(filter) && filter.indexOf(value) > -1);
+}
+
+/**
+ * Distinct filter for arrays
+ */
+function distinct(value, index, self) {
+  return self.indexOf(value) === index;
+}
+
+/**
+ * Get random element of an array
+ */
+function sample(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+export default Service.extend({
+  wikiVariables: service(),
+  geo: service(),
+
+  currentWikiId: readOnly('wikiVariables.id'),
+  currentVertical: readOnly('wikiVariables.vertical'),
+  currentCountry: readOnly('geo.country'),
+
+  /**
+   * Get one random unit from that can be displayed on current wiki with given `title`
+   */
+  getUnitOnPage(title) {
+    return sample(this.getAllUnitsOnPage(title));
+  },
+
+  /**
+   * Get all units that can be displayed on current wiki with given `title`
+   */
+  getAllUnitsOnPage(title) {
+    const availableUnitNames = this.getAvailableTargeting()
+      .filter(t => checkFilter(t.page, title))
+      .map(t => t.unit)
+      .filter(distinct);
+
+    return units.filter(u => availableUnitNames.indexOf(u.name) > -1);
+  },
+
+  /**
+   * Get one random unit from that can be displayed on current wiki with given `query`
+   */
+  getUnitOnSearch(query) {
+    return sample(this.getAllUnitsOnSearch(query));
+  },
+
+  /**
+   * Get all units that can be displayed on current wiki with given `query`
+   */
+  getAllUnitsOnSearch(query) {
+    const availableUnitNames = this.getAvailableTargeting()
+      .filter(t => checkFilter(t.query, query))
+      .map(t => t.unit)
+      .filter(distinct);
+
+    return units.filter(u => availableUnitNames.indexOf(u.name) > -1);
+  },
+
+  /**
+   * Get all targeting that can be used on current wiki; checks for:
+   * - wikiId
+   * - vertical
+   * - country
+   */
+  getAvailableTargeting() {
+    return targeting
+      .filter(t => checkFilter(t.country, this.currentCountry))
+      .filter(t => checkFilter(t.vertical, this.currentVertical))
+      .filter(t => checkFilter(t.wikiId, this.currentWikiId));
+  },
+});

--- a/app/services/affiliate-slots.js
+++ b/app/services/affiliate-slots.js
@@ -3,23 +3,21 @@ import {
 } from '@ember/object/computed';
 import Service, { inject as service } from '@ember/service';
 
-import targeting from './affiliate-slots-targeting.json';
-import units from './affiliate-slots-units.json';
+import targeting from './affiliate-slots-targeting';
+import units from './affiliate-slots-units';
 
 /**
  *  Returns `true` if filter is undefined OR if it has the value
  */
-function checkFilter(filter, value) {
-  return typeof filter === 'undefined'
-    || (Array.isArray(filter) && filter.indexOf(value) > -1);
-}
+const checkFilter = (filter, value) => (
+  typeof filter === 'undefined'
+    || (Array.isArray(filter) && (filter.length === 0 || filter.indexOf(value) > -1))
+);
 
 /**
  * Distinct filter for arrays
  */
-function distinct(value, index, self) {
-  return self.indexOf(value) === index;
-}
+const distinct = (value, index, self) => (self.indexOf(value) === index);
 
 /**
  * Get random element of an array

--- a/app/services/affiliate-slots.js
+++ b/app/services/affiliate-slots.js
@@ -48,6 +48,7 @@ export default Service.extend({
     const availableUnitNames = this.getAvailableTargeting()
       .filter(t => checkFilter(t.page, title))
       .map(t => t.unit)
+      .flat()
       .filter(distinct);
 
     return units.filter(u => availableUnitNames.indexOf(u.name) > -1);
@@ -67,6 +68,7 @@ export default Service.extend({
     const availableUnitNames = this.getAvailableTargeting()
       .filter(t => checkFilter(t.query, query))
       .map(t => t.unit)
+      .flat()
       .filter(distinct);
 
     return units.filter(u => availableUnitNames.indexOf(u.name) > -1);

--- a/app/services/affiliate-slots.md
+++ b/app/services/affiliate-slots.md
@@ -1,0 +1,68 @@
+# JSON Files
+
+## `affiliate-slots-units.json`
+
+This file defines all the available affiliate units.
+
+### Structure of a unit
+
+```json
+{
+  "name": "fandom-com",
+  "image": "https://vignette.wikia.nocookie.net/central/images/b/bc/Wiki.png/revision/latest?cb=20180423162614",
+  "heading": "Fandom",
+  "subheading": "Check this out",
+  "link": "https://fandom.com"
+},
+```
+
+### Important field
+
+* `name` -  a short description of the unit - this is being used in `affiliate-slots-targeting.json` file
+
+## `affiliate-slots-targeting.json`
+
+This file defines all the active targeting.
+
+### Structure of single targeting entry
+
+```json
+  {
+    "comment": "Fandom.com test for keiko-test wiki on searching for 'coffee'",
+    "unit": [
+      "fandom-com",
+      "fandom-com2"
+    ],
+    "wikiId": [
+      1081891,
+      123
+    ],
+    "country": [
+      "US",
+      "NL"
+    ],
+    "page": [
+      "Luke_Skywalker"
+    ],
+    "query": [
+      "coffee"
+    ],
+    "vertical": [
+      "games"
+    ]
+  },
+```
+
+### Fields
+
+**NOTE**: All the fields are arrays. If the array is empty (`[]`) **OR** it is not present in the object - filtering for that field is ignored.
+
+* `comment` - just a way to add comments to JSON; _ignored_
+* `unit` - a list of `name`s from `affiliate-slots-units.json` for that unit
+* `wikiId` - IDs of communities that the unit should display on
+* `country` - two letter name of the country (same as one that exists in `Geo` cookie) that the unit should display on
+* `page` - MW article names that the unit should display on - **NOTE** Use `false` to disable targeting on Wiki articles
+* `query` - search queries that the unit should display on - **NOTE** Use `false` to disable targeting on search page
+* `vertical` - list of verticals that the unit should display on
+
+Once again, in order to display on **ALL** wikis, use empty array for `wikiId` **OR** skip this key from the targeting definition.

--- a/app/templates/components/post-search-results.hbs
+++ b/app/templates/components/post-search-results.hbs
@@ -35,5 +35,12 @@
         </div>
       {{/each}}
     {{/if}}
+    {{#if affiliateUnit}}
+      <div>
+        <a href={{affiliateUnit.link}}>{{affiliateUnit.heading}}</a>
+        <div>{{affiliateUnit.subheading}}</div>
+        <img src={{affiliateUnit.image}} alt={{affiliateUnit.heading}}>
+      </div>
+    {{/if}}
   </aside>
 {{/if}}

--- a/app/templates/components/post-search-results.hbs
+++ b/app/templates/components/post-search-results.hbs
@@ -36,7 +36,7 @@
       {{/each}}
     {{/if}}
     {{#if affiliateUnit}}
-      <div>
+      <div style="border:1px solid #aaa;padding:15px;margin:15px;">
         <a href={{affiliateUnit.link}}>{{affiliateUnit.heading}}</a>
         <div>{{affiliateUnit.subheading}}</div>
         <img src={{affiliateUnit.image}} alt={{affiliateUnit.heading}}>

--- a/config/bundlesize.js
+++ b/config/bundlesize.js
@@ -5,7 +5,7 @@ const assetsFolder = 'mobile-wiki/assets';
 module.exports = {
   'mobile-wiki.js': {
     pattern: `${assetsFolder}/mobile-wiki-*.js`,
-    limit: '485KB',
+    limit: '487KB',
   },
   'vendor.js': {
     pattern: `${assetsFolder}/vendor-*.js`,


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/CAKE-5177

## Description

- Add new `affility-slot` service that will handle targeting params
- For now both units and targeting params are stored in JSON
- Skip targeting param or assign empty array to disable filtering by certain param
- Add test slot on search on muppet on dev and keiko-test on prod

## Reviewers

@Wikia/cake 
