### PR TITLE
CAKE-5177 | Add additional unit and targeting priorities

### DIFF
--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -1,16 +1,24 @@
 [
   {
     "name": "fandom-com",
+    "isBig": false,
     "image": "https://vignette.wikia.nocookie.net/central/images/b/bc/Wiki.png/revision/latest?cb=20180423162614",
     "heading": "Fandom",
     "subheading": "Check this out",
-    "link": "https://fandom.com"
+    "link": "https://fandom.com",
+    "isExternal": false,
+    "priority": 3,
+    "disableOnSearch": false,
+    "disableOnPage": false,
+    "onlyOnAndroid": false,
+    "onlyOnIOS": false
   },
   {
     "name": "fandom-com2",
     "image": "https://vignette.wikia.nocookie.net/central/images/b/bc/Wiki.png/revision/latest?cb=20180423162614",
     "heading": "Wikia",
     "subheading": "Ye old times",
-    "link": "https://fandom.com"
+    "link": "https://fandom.com",
+    "priority": 1
   }
 ]

--- a/app/services/affiliate-slots.js
+++ b/app/services/affiliate-slots.js
@@ -3,6 +3,8 @@ import {
 } from '@ember/object/computed';
 import Service, { inject as service } from '@ember/service';
 
+import { system } from '../utils/browser';
+
 import targeting from './affiliate-slots-targeting';
 import units from './affiliate-slots-units';
 
@@ -22,9 +24,25 @@ const distinct = (value, index, self) => (self.indexOf(value) === index);
 /**
  * Get random element of an array
  */
-function sample(arr) {
-  return arr[Math.floor(Math.random() * arr.length)];
-}
+const sample = arr => arr[Math.floor(Math.random() * arr.length)];
+
+/**
+ * Check if the unit can be displayed on current system
+ */
+const checkMobileSystem = (unit) => {
+  // if the unit is only available on ios
+  if (unit.onlyOnIOS) {
+    return system === 'ios';
+  }
+
+  // if the unit is available on android
+  if (unit.onlyOnAndroid) {
+    return system === 'android';
+  }
+
+  // carry on
+  return true;
+};
 
 export default Service.extend({
   wikiVariables: service(),
@@ -38,7 +56,7 @@ export default Service.extend({
    * Get one random unit from that can be displayed on current wiki with given `title`
    */
   getUnitOnPage(title) {
-    return sample(this.getAllUnitsOnPage(title));
+    return this.getUnitByPriority(this.getAllUnitsOnPage(title));
   },
 
   /**
@@ -46,19 +64,31 @@ export default Service.extend({
    */
   getAllUnitsOnPage(title) {
     const availableUnitNames = this.getAvailableTargeting()
+      .filter(t => !t.disableOnPage)
       .filter(t => checkFilter(t.page, title))
       .map(t => t.unit)
       .flat()
       .filter(distinct);
 
-    return units.filter(u => availableUnitNames.indexOf(u.name) > -1);
+    return units
+      .filter(u => availableUnitNames.indexOf(u.name) > -1)
+      .filter(u => checkMobileSystem(u));
   },
 
   /**
    * Get one random unit from that can be displayed on current wiki with given `query`
    */
   getUnitOnSearch(query) {
-    return sample(this.getAllUnitsOnSearch(query));
+    return this.getUnitByPriority(this.getAllUnitsOnSearch(query));
+  },
+
+  /**
+   * Sort all units via priority and fetch one of them
+   */
+  getUnitByPriority(availableUnits) {
+    return availableUnits.length > 0
+      ? sample(availableUnits.sort((a, b) => ((a.priority > b.priority) ? 1 : -1)))
+      : undefined;
   },
 
   /**
@@ -66,12 +96,15 @@ export default Service.extend({
    */
   getAllUnitsOnSearch(query) {
     const availableUnitNames = this.getAvailableTargeting()
+      .filter(t => !t.disableOnSearch)
       .filter(t => checkFilter(t.query, query))
       .map(t => t.unit)
       .flat()
       .filter(distinct);
 
-    return units.filter(u => availableUnitNames.indexOf(u.name) > -1);
+    return units
+      .filter(u => availableUnitNames.indexOf(u.name) > -1)
+      .filter(u => checkMobileSystem(u));
   },
 
   /**

--- a/app/services/affiliate-slots.js
+++ b/app/services/affiliate-slots.js
@@ -22,11 +22,6 @@ const checkFilter = (filter, value) => (
 const distinct = (value, index, self) => (self.indexOf(value) === index);
 
 /**
- * Get random element of an array
- */
-const sample = arr => arr[Math.floor(Math.random() * arr.length)];
-
-/**
  * Check if the unit can be displayed on current system
  */
 const checkMobileSystem = (unit) => {
@@ -86,9 +81,13 @@ export default Service.extend({
    * Sort all units via priority and fetch one of them
    */
   getUnitByPriority(availableUnits) {
-    return availableUnits.length > 0
-      ? sample(availableUnits.sort((a, b) => ((a.priority > b.priority) ? 1 : -1)))
-      : undefined;
+    if (availableUnits.length > 0) {
+      const sortedUnits = availableUnits.sort((a, b) => ((a.priority > b.priority) ? 1 : -1));
+
+      return sortedUnits[0];
+    }
+
+    return undefined;
   },
 
   /**

--- a/app/services/affiliate-slots.md
+++ b/app/services/affiliate-slots.md
@@ -9,16 +9,30 @@ This file defines all the available affiliate units.
 ```json
 {
   "name": "fandom-com",
+  "isBig": false,
   "image": "https://vignette.wikia.nocookie.net/central/images/b/bc/Wiki.png/revision/latest?cb=20180423162614",
   "heading": "Fandom",
   "subheading": "Check this out",
-  "link": "https://fandom.com"
+  "link": "https://fandom.com",
+  "isExternal": false,
+  "priority": 3,
+  "disableOnSearch": false,
+  "disableOnPage": false,
+  "onlyOnAndroid": false,
+  "onlyOnIOS": false
 },
 ```
 
 ### Important field
 
 * `name` -  a short description of the unit - this is being used in `affiliate-slots-targeting.json` file
+* `isBig` - defaults to false. If set to true the unit will be tke over the post search results.
+* `isExternal` - defaults to false. If set to true the link is external and should be styled that way.
+* `priority` - a numerical priority. The higher the number, the more important unit is.
+* `disableOnSearch` - optional property. If set to true the unit is never going to be displayed on Search results.
+* `disableOnPage` - optional property. If set to true the unit is never going to be displayed on Pages results.
+* `onlyOnAndroid` - optional property. If set to true the unit is never going to be displayed on non-Android devices.
+* `onlyOnIOS` - optional property. If set to true the unit is never going to be displayed on non-iOS devices.
 
 ## `affiliate-slots-targeting.json`
 


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/CAKE-5177

## Description

- Add two more properties to unit to drive the looks: `isBig` and `isExternal`
- Add priority to units and use that to determine which unit should be more important to display
- Add `onlyOnAndorid` and `onlyOnIOS` flags
- Add `disableOnSearch` and `disableOnPage` flags

## Reviewers

@Wikia/cake 
