### PR TITLE
Revert "Revert "ADEN-9552 Trigger page tracking only in afterRenderEnded callback. (#…""

### DIFF
--- a/app/modules/ads/index.js
+++ b/app/modules/ads/index.js
@@ -257,6 +257,7 @@ class Ads {
     });
 
     this.triggerAfterPageRenderServices();
+    this.triggerPageTracking();
 
     utils.logger(logGroup, 'after transition');
   }
@@ -319,7 +320,6 @@ class Ads {
 
     this.callExternalTrackingServices();
     adblockDetector.run();
-    this.triggerPageTracking();
   }
 
   /**


### PR DESCRIPTION
Reverts Wikia/mobile-wiki#1857

This doesn't appear to be the root cause of the p2 https://wikia-inc.atlassian.net/browse/IW-2654?utm_term=&utm_source=jira-slack&utm_medium=referral-external&atlOrigin=eyJpIjoiNjZkYjE0NTE0YzM1NDBlNDkyODdiN2MwZDk1ZDcyNmEiLCJwIjoiamlyYS1zbGFjay1pbnQifQ