### PR TITLE
CAKE-5259 | Put affiliate work behind flag and add query param for testing

### DIFF
--- a/app/components/article-content.js
+++ b/app/components/article-content.js
@@ -41,6 +41,7 @@ export default Component.extend(
     id: null,
     isPreview: false,
     media: null,
+    debugAffiliateUnits: false,
 
     lang: reads('wikiVariables.language.content'),
     dir: reads('wikiVariables.language.contentDir'),
@@ -621,7 +622,7 @@ export default Component.extend(
       }
 
       this.affiliateSlots
-        .fetchUnitForPage(this.id, true)
+        .fetchUnitForPage(this.id, true, this.debugAffiliateUnits)
         .then(unit => {
           if (typeof unit === 'undefined') {
             // There's no unit to display (not an error)
@@ -656,7 +657,7 @@ export default Component.extend(
       }
 
       this.affiliateSlots
-        .fetchUnitForPage(this.id, false)
+        .fetchUnitForPage(this.id, false, this.debugAffiliateUnits)
         .then(unit => {
           if (typeof unit === 'undefined') {
             // There's no unit to display (not an error)

--- a/app/components/post-search-interrupt.js
+++ b/app/components/post-search-interrupt.js
@@ -12,16 +12,18 @@ export default Component.extend({
   isSmallFinished: false,
 
   isEnabled: and('isBigFinished', 'isSmallFinished'),
+  debugAffiliateUnits: false,
 
   init() {
     this._super(...arguments);
 
-    this.affiliateSlots.fetchUnitForSearch(this.query, false).then(u => {
+
+    this.affiliateSlots.fetchUnitForSearch(this.query, false, this.debugAffiliateUnits).then(u => {
       this.set('smallUnit', u);
       this.set('isSmallFinished', true);
     });
 
-    this.affiliateSlots.fetchUnitForSearch(this.query, true).then(u => {
+    this.affiliateSlots.fetchUnitForSearch(this.query, true, this.debugAffiliateUnits).then(u => {
       this.set('bigUnit', u);
       this.set('isBigFinished', true);
     });

--- a/app/components/post-search-results.js
+++ b/app/components/post-search-results.js
@@ -70,6 +70,7 @@ export default Component.extend({
   isCrossWiki: false,
   posts: null,
   unit: null,
+  debugAffiliateUnits: false,
 
   // TODO: Use when releasing search for all post types
   // seeMoreButtonEnabled: not('isCrossWiki'),
@@ -156,6 +157,7 @@ export default Component.extend({
     if (!this.isDestroyed) {
       const results = state.results.map(item => extend({}, item));
 
+      // check query param here
       if (this.unit) {
         const unit = this.unit;
         const preferredIndex = getAffiliateSlot(unit, state.results);

--- a/app/models/search.js
+++ b/app/models/search.js
@@ -22,6 +22,7 @@ export default EmberObject.extend({
   tracing: service(),
   scope: 'internal',
   isInteralScope: equal('scope', 'internal'),
+  debugAffiliateUnits: '',
 
   canLoadMore: computed('batch', 'totalBatches', function () {
     return this.batch + 1 < this.totalBatches;
@@ -32,9 +33,13 @@ export default EmberObject.extend({
     this.set('items', A([]));
   },
 
-  search(query, scope) {
+  search(query, scope, debugAffiliateUnits) {
     if (isEmpty(scope)) {
       scope = 'internal';
+    }
+
+    if (isEmpty(debugAffiliateUnits)) {
+      debugAffiliateUnits = false;
     }
 
     this.setProperties({
@@ -44,6 +49,7 @@ export default EmberObject.extend({
       query,
       items: A([]),
       scope,
+      debugAffiliateUnits,
     });
 
     if (query) {
@@ -64,6 +70,7 @@ export default EmberObject.extend({
   },
 
   fetchResults(query) {
+    console.log('param', this.debugAffiliateUnits, this.get('debugAffiliateUnits'));
     this.setProperties({
       error: '',
       loading: true,

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -30,6 +30,9 @@ export default Route.extend(
       scope: {
         refreshModel: true,
       },
+      debugAffiliateUnits: {
+        refreshModel: true,
+      },
     },
 
     applicationWrapperClassNames: null,
@@ -58,7 +61,7 @@ export default Route.extend(
 
       return SearchModel
         .create(getOwner(this).ownerInjection())
-        .search(params.query, params.scope);
+        .search(params.query, params.scope, params.debugAffiliateUnits ? params.debugAffiliateUnits : false);
     },
 
     actions: {

--- a/app/routes/wiki-page.js
+++ b/app/routes/wiki-page.js
@@ -54,6 +54,9 @@ export default Route.extend(
         // but I wasn't able to reload the model on history change
         replace: true,
       },
+      debugAffiliateUnits: {
+        refreshModel: true,
+      },
     },
 
     redirectEmptyTarget: false,
@@ -113,6 +116,10 @@ export default Route.extend(
 
       if (params.from) {
         modelParams.from = params.from;
+      }
+
+      if (params.debugAffiliateUnits) {
+        modelParams.debugAffiliateUnits = params.debugAffiliateUnits;
       }
 
       return resolve(this.getPageModel(modelParams));

--- a/app/services/affiliate-slots.js
+++ b/app/services/affiliate-slots.js
@@ -155,10 +155,25 @@ export default Service.extend({
     return false;
   },
 
+  _getDebugUnit(debugString, isBig) {
+    const debugArray = debugString.split(',');
+    const campaign = debugArray[0];
+    const category = debugArray[1];
+
+    return units.find((unit) => {
+      return unit.campaign === campaign && unit.category === category && !!unit.isBig === isBig;
+    });
+  },
+
   fetchUnitForSearch(query, isBig = false, debugAffiliateUnits = false) {
     return new Promise((resolve, reject) => {
       if (!this._isLaunched() && !debugAffiliateUnits) {
         resolve(undefined);
+      }
+
+      // special use case for debuggin
+      if (debugAffiliateUnits.indexOf(',') > -1) {
+        resolve(this._getDebugUnit(debugAffiliateUnits, isBig))
       }
 
       // check if we have possible units (we can fail early if we don't)
@@ -183,6 +198,11 @@ export default Service.extend({
     return new Promise((resolve, reject) => {
       if (!this._isLaunched() && !debugAffiliateUnits) {
         resolve(undefined);
+      }
+
+      // special use case for debuggin
+      if (debugAffiliateUnits.indexOf(',') > -1) {
+        resolve(this._getDebugUnit(debugAffiliateUnits, isBig))
       }
 
       // check if we have possible units (we can fail early if we don't)

--- a/app/services/affiliate-slots.js
+++ b/app/services/affiliate-slots.js
@@ -149,8 +149,18 @@ export default Service.extend({
       .filter(t => checkFilter(t.query, query));
   },
 
-  fetchUnitForSearch(query, isBig = false) {
+  _isLaunched() {
+    // check/pass in the wikifactory date here
+    // return launchDate > wfData;
+    return false;
+  },
+
+  fetchUnitForSearch(query, isBig = false, debugAffiliateUnits = false) {
     return new Promise((resolve, reject) => {
+      if (!this._isLaunched() && !debugAffiliateUnits) {
+        resolve(undefined);
+      }
+
       // check if we have possible units (we can fail early if we don't)
       if (!this._getAvailableUnits()) {
         resolve(undefined);
@@ -159,23 +169,27 @@ export default Service.extend({
       // get the units that fulfill the targeting on search
       const targeting = this._getTargetingOnSearch(query);
       const units = this._getUnitsWithTargeting(targeting)
-        // filter type of ad - isBig can be undefined, let's convert both to boolean 
+        // filter type of ad - isBig can be undefined, let's convert both to boolean
         .filter(u => !!u.isBig === !!isBig)
         // filter units disabled on search page
         .filter(u => !u.disableOnSearch);
-      
+
       // fetch only the first unit if available
       resolve(units.length > 0 ? units[0] : undefined);
     });
   },
 
-  fetchUnitForPage(id, isBig = false) {
+  fetchUnitForPage(id, isBig = false, debugAffiliateUnits = false) {
     return new Promise((resolve, reject) => {
+      if (!this._isLaunched() && !debugAffiliateUnits) {
+        resolve(undefined);
+      }
+
       // check if we have possible units (we can fail early if we don't)
       if (!this._getAvailableUnits()) {
         resolve(undefined);
       }
-      
+
       const url = this.fetch.getServiceUrl('knowledge-graph', `/affiliates/${this.currentWikiId}/${id}`);
 
       this.fetch.fetchAndParseResponse(url, {}, AffiiatesFetchError)
@@ -200,7 +214,7 @@ export default Service.extend({
 
           // get the units that fulfill the campaign and category
           const units = this._getUnitsWithTargeting(targeting)
-            // filter type of ad - isBig can be undefined, let's convert both to boolean 
+            // filter type of ad - isBig can be undefined, let's convert both to boolean
             .filter(u => !!u.isBig === !!isBig)
             // filter units disabled on article page
             .filter(u => !u.disableOnPage);

--- a/app/templates/components/article-wrapper.hbs
+++ b/app/templates/components/article-wrapper.hbs
@@ -34,6 +34,7 @@
     id=model.id
     media=model.media
     data-test-article-content=true
+    debugAffiliateUnits=model.debugAffiliateUnits
   }}
 </section>
 {{yield}}

--- a/app/templates/components/post-search-interrupt.hbs
+++ b/app/templates/components/post-search-interrupt.hbs
@@ -7,6 +7,6 @@
       subheading=bigUnit.subheading
     }}
   {{else}}
-    {{post-search-results query=query unit=smallUnit isCrossWiki=isCrossWiki}}
+    {{post-search-results query=query unit=smallUnit isCrossWiki=isCrossWiki debugAffiliateUnits=debugAffiliateUnits}}
   {{/if}}
 {{/if}}

--- a/app/templates/components/wikia-ui-components/wikia-card-crosswiki-list.hbs
+++ b/app/templates/components/wikia-ui-components/wikia-card-crosswiki-list.hbs
@@ -11,7 +11,7 @@
     </li>
     {{#if includePostsForQuery}}
       {{#if (equal key 1)}}
-        {{post-search-interrupt query=includePostsForQuery isCrossWiki=true}}
+        {{post-search-interrupt query=includePostsForQuery isCrossWiki=true debugAffiliateUnits=debugAffiliateUnits}}
       {{/if}}
     {{/if}}
   {{/each}}

--- a/app/templates/components/wikia-ui-components/wikia-card-list.hbs
+++ b/app/templates/components/wikia-ui-components/wikia-card-list.hbs
@@ -16,7 +16,7 @@
     </li>
     {{#if includePostsForQuery}}
       {{#if (equal key 1)}}
-        {{post-search-interrupt query=includePostsForQuery}}
+        {{post-search-interrupt query=includePostsForQuery debugAffiliateUnits=debugAffiliateUnits}}
       {{/if}}
     {{/if}}
   {{/each}}

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -47,6 +47,7 @@
         trackingCategory="search-page"
         trackingLabel="search-result"
         itemClick=(action "onResultClick")
+        debugAffiliateUnits=model.debugAffiliateUnits
       }}
     {{/if}}
   {{else if notFoundError}}

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -38,6 +38,7 @@
         trackingCategory="search-page"
         trackingLabel="search-result"
         itemClick=(action "onResultClick")
+        debugAffiliateUnits=model.debugAffiliateUnits
       }}
     {{else}}
       {{wikia-ui-components/wikia-card-crosswiki-list


### PR DESCRIPTION
## Description
Add placeholder where we will check the WF variable for the date (`_isLaunched`) and add query param `debugAffiliateUnits` which has two formats `debugAffiliateUnits=true` allows the normal targeting to work and will only show up when it meets the criteria or `debugAffiliateUnits=fandom-test,fandom-test` which will force cany `<campign>,<category>` to show up. 

@Wikia/cake 