### PR TITLE
CAKE-5248 Disney+ affiliate ad targeting

### DIFF
--- a/app/services/affiliate-slots-targeting.json
+++ b/app/services/affiliate-slots-targeting.json
@@ -1,43 +1,74 @@
 [
   {
-    "campaign": "fandom-test",
-    "category": "fandom-test",
+    "campaign": "disneyplus",
+    "category": "disney",
     "wikiId": [
-      1081891
-    ],
-    "query": [
-      "coffee"
+      374,
+      2233,
+      177996,
+      147,
+      4097,
+      673
     ]
   },
   {
-    "campaign": "fandom-test",
-    "category": "fandom-test",
+    "campaign": "disneyplus",
+    "category": "mandalorian",
     "wikiId": [
-      1081891
-    ],
-    "query": [
-      "foo"
+      374,
+      2233,
+      177996,
+      147,
+      4097,
+      673
     ]
   },
   {
-    "campaign": "fandom-test",
-    "category": "fandom-test-search-big",
+    "campaign": "disneyplus",
+    "category": "marvel",
     "wikiId": [
-      1575417,
-      1619010
-    ],
-    "query": [
-      "spiderman",
-      "marvel",
-      "test"
+      374,
+      2233,
+      177996,
+      147,
+      4097,
+      673
     ]
   },
   {
-    "campaign": "fandom-test",
-    "category": "fandom-test-search",
+    "campaign": "disneyplus",
+    "category": "pixar",
     "wikiId": [
-      1575417,
-      1619010
+      374,
+      2233,
+      177996,
+      147,
+      4097,
+      673
+    ]
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "starwars",
+    "wikiId": [
+      374,
+      2233,
+      177996,
+      147,
+      4097,
+      673
+    ]
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "simpsons",
+    "wikiId": [
+      374,
+      2233,
+      177996,
+      147,
+      4097,
+      673
     ]
   }
 ]

--- a/app/services/affiliate-slots-targeting.json
+++ b/app/services/affiliate-slots-targeting.json
@@ -3,71 +3,42 @@
     "campaign": "disneyplus",
     "category": "disney",
     "wikiId": [
-      374,
-      2233,
-      177996,
-      147,
-      4097,
-      673
+      374
     ]
   },
   {
     "campaign": "disneyplus",
     "category": "mandalorian",
     "wikiId": [
-      374,
-      2233,
-      177996,
-      147,
-      4097,
-      673
+      147
     ]
   },
   {
     "campaign": "disneyplus",
     "category": "marvel",
     "wikiId": [
-      374,
       2233,
-      177996,
-      147,
-      4097,
-      673
+      177996
     ]
   },
   {
     "campaign": "disneyplus",
     "category": "pixar",
     "wikiId": [
-      374,
-      2233,
-      177996,
-      147,
-      4097,
-      673
+      4097
     ]
   },
   {
     "campaign": "disneyplus",
     "category": "starwars",
     "wikiId": [
-      374,
-      2233,
-      177996,
-      147,
-      4097,
-      673
+      147
     ]
   },
   {
     "campaign": "disneyplus",
     "category": "simpsons",
     "wikiId": [
-      374,
-      2233,
-      177996,
-      147,
-      4097,
       673
     ]
   }

--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -1,48 +1,104 @@
 [
   {
-    "campaign": "fandom-test",
-    "category": "fandom-test",
-    "isBig": false,
-    "image": "https://vignette.wikia.nocookie.net/central/images/b/bc/Wiki.png/revision/latest?cb=20180423162614",
-    "heading": "Ewan McGregor Returns as Obi-Wan Kenobi in Disney+ Series",
-    "subheading": "Presented by Disney+",
-    "link": "https://fandom.com",
-    "isExternal": false,
-    "priority": 3,
-    "disableOnSearch": false,
-    "disableOnPage": false,
-    "onlyOnAndroid": false,
-    "onlyOnIOS": false
+    "campaign": "disneyplus",
+    "category": "disney",
+    "image": "https://static.wikia.nocookie.net/a136ba04-c922-40f2-89a6-f455b5ce895a",
+    "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
+    "subheading": "Watch It On Disney+",
+    "country": ["US", "CA", "NL"]
   },
   {
-    "campaign": "fandom-test",
-    "category": "fandom-test",
-    "isBig": true,
-    "image": "https://vignette.wikia.nocookie.net/central/images/b/bc/Wiki.png/revision/latest?cb=20180423162614",
-    "heading": "BIG Ewan McGregor Returns as Obi-Wan Kenobi in Disney+ Series",
-    "subheading": "Presented by Disney+",
-    "link": "https://fandom.com",
-    "priority": 2
+    "campaign": "disneyplus",
+    "category": "disney",
+    "image": "https://static.wikia.nocookie.net/a136ba04-c922-40f2-89a6-f455b5ce895a",
+    "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
+    "subheading": "Watch It On Disney+",
+    "country": ["US", "CA", "NL"],
+    "isBig": true
   },
   {
-    "campaign": "fandom-test",
-    "category": "fandom-test-search-big",
-    "isBig": true,
-    "image": "https://vignette.wikia.nocookie.net/central/images/b/bc/Wiki.png/revision/latest?cb=20190830144754",
-    "heading": "BIG Ewan McGregor Returns as Obi-Wan Kenobi in Disney+ Series",
-    "subheading": "Presented by Disney+",
-    "link": "https://www.fandom.com",
-    "isExternal": false,
-    "priority": 1
+    "campaign": "disneyplus",
+    "category": "mandalorian",
+    "image": "https://static.wikia.nocookie.net/a2ea4f98-6c5b-4cf3-9ee8-e58ec23ba686",
+    "heading": "A thrilling new adventure on the galactic frontier",
+    "subheading": "Watch It On Disney+",
+    "country": ["US", "CA", "NL"]
   },
   {
-    "campaign": "fandom-test",
-    "category": "fandom-test-search",
-    "image": "https://vignette.wikia.nocookie.net/central/images/b/bc/Wiki.png/revision/latest?cb=20180423162614",
-    "heading": "Ewan McGregor Returns as Obi-Wan Kenobi in Disney+ Series",
-    "subheading": "Presented by Disney+",
-    "link": "https://www.fandom.com",
-    "isExternal": false,
-    "priority": 2
+    "campaign": "disneyplus",
+    "category": "mandalorian",
+    "image": "https://static.wikia.nocookie.net/a2ea4f98-6c5b-4cf3-9ee8-e58ec23ba686",
+    "heading": "A thrilling new adventure on the galactic frontier",
+    "subheading": "Watch It On Disney+",
+    "country": ["US", "CA", "NL"],
+    "isBig": true
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "marvel",
+    "image": "https://static.wikia.nocookie.net/d8374c50-15b4-4ee6-97be-fa8dc4d5976e",
+    "heading": "All Avengers, All the Time",
+    "subheading": "Watch It On Disney+",
+    "country": ["US", "CA", "NL"]
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "marvel",
+    "image": "https://static.wikia.nocookie.net/d8374c50-15b4-4ee6-97be-fa8dc4d5976e",
+    "heading": "All Avengers, All the Time",
+    "subheading": "Watch It On Disney+",
+    "country": ["US", "CA", "NL"],
+    "isBig": true
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "pixar",
+    "image": "https://static.wikia.nocookie.net/5815ecac-01d2-4330-9116-887172ced2af",
+    "heading": "The Incredibles- a family who saves the world together sticks together",
+    "subheading": "Watch It On Disney+",
+    "country": ["US", "CA", "NL"]
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "pixar",
+    "image": "https://static.wikia.nocookie.net/5815ecac-01d2-4330-9116-887172ced2af",
+    "heading": "The Incredibles- a family who saves the world together sticks together",
+    "subheading": "Watch It On Disney+",
+    "country": ["US", "CA", "NL"],
+    "isBig": true
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "starwars",
+    "image": "https://static.wikia.nocookie.net/29803c98-f93a-4291-bda3-8b44c8bbfcab",
+    "heading": "The Star Wars story lives forever",
+    "subheading": "Watch It On Disney+",
+    "country": ["US", "CA", "NL"]
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "starwars",
+    "image": "https://static.wikia.nocookie.net/29803c98-f93a-4291-bda3-8b44c8bbfcab",
+    "heading": "The Star Wars story lives forever",
+    "subheading": "Watch It On Disney+",
+    "country": ["US", "CA", "NL"],
+    "isBig": true
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "simpsons",
+    "image": "https://static.wikia.nocookie.net/2d18111c-bc45-458f-9898-d2d4e3a50589",
+    "heading": "Don't have a cow man, relive the Simpsons",
+    "subheading": "Watch It On Disney+",
+    "country": ["US", "CA", "NL"]
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "simpsons",
+    "image": "https://static.wikia.nocookie.net/2d18111c-bc45-458f-9898-d2d4e3a50589",
+    "heading": "Don't have a cow man, relive the Simpsons",
+    "subheading": "Watch It On Disney+",
+    "country": ["US", "CA", "NL"],
+    "isBig": true
   }
 ]


### PR DESCRIPTION
## Links
* http://wikia-inc.atlassian.net/browse/CAKE-5248

## Description
Use production-ready json data for Disney+ affiliate ad targeting.

## Reviewers
@Wikia/cake 