### PR TITLE
CAKE-5234 Fix call to nonexistent method

### DIFF
--- a/app/components/article-content.js
+++ b/app/components/article-content.js
@@ -678,6 +678,7 @@ export default Component.extend(
               query: this.title,
               unit,
               isCrossWiki: true,
+              setHasAffiliateUnit: this.setHasAffiliateUnit,
             },
             element: unitPlaceholder,
           }));


### PR DESCRIPTION
## Links
* http://wikia-inc.atlassian.net/browse/CAKE-5234

## Description
The existing code didn't account for showing the disclaimer in the case of a search result affiliate unit appearing on the article page. This resulted in an error because the method wasn't passed to the component attributes.

@Wikia/cake 