### PR TITLE
CAKE-5251 Fix placement of 'watch show' in DOM

### DIFF
--- a/app/components/article-content.js
+++ b/app/components/article-content.js
@@ -64,9 +64,9 @@ export default Component.extend(
 
           this.handleBigAffiliateUnit();
           this.handlePostSearchResults();
-          this.handleWatchShow();
           this.handleInfoboxes();
           this.replaceInfoboxesWithInfoboxComponents();
+          this.handleWatchShow();
 
           this.renderDataComponents(this.element);
 
@@ -590,14 +590,11 @@ export default Component.extend(
      * Injects watch show button (IW-1470) just after the first infobox
      */
     handleWatchShow() {
-      const infobox = this.element.querySelector('.portable-infobox,.infobox');
+      const infoboxWrapper = this.element.querySelector('.portable-infobox-wrapper');
 
-      if (infobox) {
+      if (infoboxWrapper) {
         const placeholder = document.createElement('div');
-        const wrapper = document.createElement('div');
-
-        wrapper.appendChild(placeholder);
-        infobox.insertAdjacentElement('afterend', wrapper);
+        infoboxWrapper.appendChild(placeholder);
 
         this.renderedComponents.push(this.renderComponent({
           name: 'watch-show',


### PR DESCRIPTION
## Links
* http://wikia-inc.atlassian.net/browse/CAKE-5251

## Description
Places the "watch show" promo unit where it should be, to prevent the top leaderboard ad from appearing above it. With the existing logic, for whatever reason, Ember inserts the "watch show" component inside the top leaderboard container. With this fix, we instead wait until the infobox is replaced with the Ember component, which includes the `.portable-infobox-wrapper`. Then we put the "watch show" component inside that.

## Reviewers
@Wikia/cake 