### PR TITLE
CAKE-5276 Use official affiliate links for Disney+ campaigns

### DIFF
--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -5,7 +5,7 @@
     "image": "https://static.wikia.nocookie.net/a136ba04-c922-40f2-89a6-f455b5ce895a",
     "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
     "subheading": "Watch Now On Disney+",
-    "link": "https://www.fandom.com",
+    "link": "https://disneyplus.bn5x.net/DrrRa",
     "country": ["US", "CA", "NL"]
   },
   {
@@ -14,7 +14,7 @@
     "image": "https://static.wikia.nocookie.net/a136ba04-c922-40f2-89a6-f455b5ce895a",
     "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
     "subheading": "Watch Now On Disney+",
-    "link": "https://www.fandom.com",
+    "link": "https://disneyplus.bn5x.net/DrrRa",
     "country": ["US", "CA", "NL"],
     "isBig": true
   },
@@ -24,7 +24,7 @@
     "image": "https://static.wikia.nocookie.net/a2ea4f98-6c5b-4cf3-9ee8-e58ec23ba686",
     "heading": "A thrilling new adventure on the galactic frontier",
     "subheading": "Watch Now On Disney+",
-    "link": "https://www.fandom.com",
+    "link": "https://disneyplus.bn5x.net/333RX",
     "country": ["US", "CA", "NL"]
   },
   {
@@ -33,7 +33,7 @@
     "image": "https://static.wikia.nocookie.net/a2ea4f98-6c5b-4cf3-9ee8-e58ec23ba686",
     "heading": "A thrilling new adventure on the galactic frontier",
     "subheading": "Watch Now On Disney+",
-    "link": "https://www.fandom.com",
+    "link": "https://disneyplus.bn5x.net/333RX",
     "country": ["US", "CA", "NL"],
     "isBig": true
   },
@@ -43,7 +43,7 @@
     "image": "https://static.wikia.nocookie.net/d8374c50-15b4-4ee6-97be-fa8dc4d5976e",
     "heading": "All Avengers, All the Time",
     "subheading": "Watch Now On Disney+",
-    "link": "https://www.fandom.com",
+    "link": "https://disneyplus.bn5x.net/beeqP",
     "country": ["US", "CA", "NL"]
   },
   {
@@ -52,7 +52,7 @@
     "image": "https://static.wikia.nocookie.net/d8374c50-15b4-4ee6-97be-fa8dc4d5976e",
     "heading": "All Avengers, All the Time",
     "subheading": "Watch Now On Disney+",
-    "link": "https://www.fandom.com",
+    "link": "https://disneyplus.bn5x.net/beeqP",
     "country": ["US", "CA", "NL"],
     "isBig": true
   },
@@ -62,7 +62,7 @@
     "image": "https://static.wikia.nocookie.net/5815ecac-01d2-4330-9116-887172ced2af",
     "heading": "The Incredibles- a family who saves the world together sticks together",
     "subheading": "Watch Now On Disney+",
-    "link": "https://www.fandom.com",
+    "link": "https://disneyplus.bn5x.net/NVVXv",
     "country": ["US", "CA", "NL"]
   },
   {
@@ -71,7 +71,7 @@
     "image": "https://static.wikia.nocookie.net/5815ecac-01d2-4330-9116-887172ced2af",
     "heading": "The Incredibles- a family who saves the world together sticks together",
     "subheading": "Watch Now On Disney+",
-    "link": "https://www.fandom.com",
+    "link": "https://disneyplus.bn5x.net/NVVXv",
     "country": ["US", "CA", "NL"],
     "isBig": true
   },
@@ -81,7 +81,7 @@
     "image": "https://static.wikia.nocookie.net/29803c98-f93a-4291-bda3-8b44c8bbfcab",
     "heading": "The Star Wars story lives forever",
     "subheading": "Watch Now On Disney+",
-    "link": "https://www.fandom.com",
+    "link": "https://disneyplus.bn5x.net/333RX",
     "country": ["US", "CA", "NL"]
   },
   {
@@ -90,7 +90,7 @@
     "image": "https://static.wikia.nocookie.net/29803c98-f93a-4291-bda3-8b44c8bbfcab",
     "heading": "The Star Wars story lives forever",
     "subheading": "Watch Now On Disney+",
-    "link": "https://www.fandom.com",
+    "link": "https://disneyplus.bn5x.net/333RX",
     "country": ["US", "CA", "NL"],
     "isBig": true
   },
@@ -100,7 +100,7 @@
     "image": "https://static.wikia.nocookie.net/2d18111c-bc45-458f-9898-d2d4e3a50589",
     "heading": "Don't have a cow man, relive the Simpsons",
     "subheading": "Watch Now On Disney+",
-    "link": "https://www.fandom.com",
+    "link": "https://disneyplus.bn5x.net/DrrRa",
     "country": ["US", "CA", "NL"]
   },
   {
@@ -109,7 +109,7 @@
     "image": "https://static.wikia.nocookie.net/2d18111c-bc45-458f-9898-d2d4e3a50589",
     "heading": "Don't have a cow man, relive the Simpsons",
     "subheading": "Watch Now On Disney+",
-    "link": "https://www.fandom.com",
+    "link": "https://disneyplus.bn5x.net/DrrRa",
     "country": ["US", "CA", "NL"],
     "isBig": true
   }


### PR DESCRIPTION
## Links
* http://wikia-inc.atlassian.net/browse/CAKE-5276

## Description
Add finalized affiliate links for Disney+ campaigns
