### PR TITLE
CAKE-5276 Fix affiliate unit disclaimer logic

### DIFF
--- a/app/components/affiliate-unit.js
+++ b/app/components/affiliate-unit.js
@@ -8,6 +8,9 @@ export default Component.extend({
   classNames: ['affiliate-unit'],
   didInsertElement() {
     this._super(...arguments);
+    // For showing the disclaimer text
+    this.setHasAffiliateUnit();
+
     if (this.isIncontent) {
       trackAffiliateUnit(this.unit, {
         action: trackActions.impression,

--- a/app/components/article-content.js
+++ b/app/components/article-content.js
@@ -642,12 +642,10 @@ export default Component.extend(
             attrs: {
               unit,
               isInContent: true,
+              setHasAffiliateUnit: this.setHasAffiliateUnit,
             },
             element: unitPlaceholder,
           }));
-
-          // So that the article-wrapper can show the disclaimer
-          this.setHasAffiliateUnit();
         });
     },
 
@@ -695,9 +693,6 @@ export default Component.extend(
             },
             element: unitPlaceholder,
           }));
-
-          // So that the article-wrapper can show the disclaimer
-          this.setHasAffiliateUnit();
         });
     },
   },

--- a/app/components/post-search-results-affiliate-item.js
+++ b/app/components/post-search-results-affiliate-item.js
@@ -8,7 +8,7 @@ export default Component.extend({
   classNames: ['post-search-results-affiliate-item'],
 
   didRender() {
-    // So that the search controller can show the disclaimer
+    // For showing the disclaimer text
     this.setHasAffiliateUnit();
   },
 

--- a/app/templates/components/post-search-interrupt.hbs
+++ b/app/templates/components/post-search-interrupt.hbs
@@ -2,6 +2,7 @@
   {{#if bigUnit}}
     {{affiliate-unit
       unit=bigUnit
+      setHasAffiliateUnit=setHasAffiliateUnit
     }}
   {{else}}
     {{post-search-results


### PR DESCRIPTION
## Links
* http://wikia-inc.atlassian.net/browse/CAKE-5276

## Description
Makes the logic more consistent for the affiliate unit disclaimer, so that the unit's component itself is always responsible for telling ancestor components that it has rendered.

Tested for both article and search result pages.

## Reviewers
@Wikia/cake 