### PR TITLE
CAKE-5282 | Trigger impression only when in viewport

### DIFF
--- a/app/components/affiliate-unit.js
+++ b/app/components/affiliate-unit.js
@@ -19,13 +19,13 @@ export default Component.extend(
         if (this.isIncontent) {
           trackAffiliateUnit(this.unit, {
             action: trackActions.click,
-            category: 'mercury-affiliate_incontent_recommend',
+            category: 'affiliate_incontent_recommend',
             label: 'only-item',
           });
         } else {
           trackAffiliateUnit(this.unit, {
             action: trackActions.click,
-            category: 'mercury-affiliate_search_recommend',
+            category: 'affiliate_search_recommend',
             label: 'only-item',
           });
         }
@@ -36,13 +36,13 @@ export default Component.extend(
       if (this.isIncontent) {
         trackAffiliateUnit(this.unit, {
           action: trackActions.impression,
-          category: 'mercury-affiliate_incontent_recommend',
+          category: 'affiliate_incontent_recommend',
           label: 'affiliate_shown',
         });
       } else {
         trackAffiliateUnit(this.unit, {
           action: trackActions.impression,
-          category: 'mercury-affiliate_search_recommend',
+          category: 'affiliate_search_recommend',
           label: 'affiliate_shown',
         });
       }

--- a/app/components/affiliate-unit.js
+++ b/app/components/affiliate-unit.js
@@ -1,46 +1,51 @@
 import Component from '@ember/component';
+import InViewportMixin from 'ember-in-viewport';
 import { trackAffiliateUnit, trackActions } from '../utils/track';
 
-export default Component.extend({
-  isIncontent: false,
-  unit: null,
+export default Component.extend(
+  InViewportMixin,
+  {
+    isIncontent: false,
+    unit: null,
 
-  classNames: ['affiliate-unit'],
-  didInsertElement() {
-    this._super(...arguments);
-    // For showing the disclaimer text
-    this.setHasAffiliateUnit();
+    classNames: ['affiliate-unit'],
+    didInsertElement() {
+      this._super(...arguments);
+      // For showing the disclaimer text
+      this.setHasAffiliateUnit();
+    },
+    actions: {
+      trackAffiliateClick() {
+        if (this.isIncontent) {
+          trackAffiliateUnit(this.unit, {
+            action: trackActions.click,
+            category: 'mercury-affiliate_incontent_recommend',
+            label: 'only-item',
+          });
+        } else {
+          trackAffiliateUnit(this.unit, {
+            action: trackActions.click,
+            category: 'mercury-affiliate_search_recommend',
+            label: 'only-item',
+          });
+        }
+      },
+    },
 
-    if (this.isIncontent) {
-      trackAffiliateUnit(this.unit, {
-        action: trackActions.impression,
-        category: 'mercury-affiliate_incontent_recommend',
-        label: 'affiliate_shown',
-      });
-    } else {
-      trackAffiliateUnit(this.unit, {
-        action: trackActions.impression,
-        category: 'mercury-affiliate_search_recommend',
-        label: 'affiliate_shown',
-      });
-    }
-  },
-  actions: {
-    trackAffiliateClick() {
+    didEnterViewport() {
       if (this.isIncontent) {
         trackAffiliateUnit(this.unit, {
-          action: trackActions.click,
+          action: trackActions.impression,
           category: 'mercury-affiliate_incontent_recommend',
-          label: 'only-item',
+          label: 'affiliate_shown',
         });
       } else {
         trackAffiliateUnit(this.unit, {
-          action: trackActions.click,
+          action: trackActions.impression,
           category: 'mercury-affiliate_search_recommend',
-          label: 'only-item',
+          label: 'affiliate_shown',
         });
       }
     },
   },
-
-});
+);

--- a/app/components/article-content.js
+++ b/app/components/article-content.js
@@ -625,7 +625,7 @@ export default Component.extend(
           // We want to know if we have targeting but no space for the unit
           if (!h2Elements[indexForUnit]) {
             trackAffiliateUnit(unit, {
-              category: 'mercury-affiliate_incontent_recommend',
+              category: 'affiliate_incontent_recommend',
               label: 'affiliate_not_shown',
               action: 'no-impression',
             });
@@ -670,7 +670,7 @@ export default Component.extend(
           // We want to know if we have targeting but no space for the unit
           if (!h2Elements[indexForUnit]) {
             trackAffiliateUnit(unit, {
-              category: 'mercury-affiliate_incontent_posts',
+              category: 'affiliate_incontent_posts',
               label: 'affiliate_not_shown',
               action: 'no-impression',
             });

--- a/app/components/post-search-results-affiliate-item.js
+++ b/app/components/post-search-results-affiliate-item.js
@@ -17,13 +17,13 @@ export default Component.extend({
       if (this.isInContent) {
         trackAffiliateUnit(unit, {
           action: trackActions.click,
-          category: 'mercury-affiliate_incontent_posts',
+          category: 'affiliate_incontent_posts',
           label: `item-${parseInt(number, 10)}`,
         });
       } else {
         trackAffiliateUnit(unit, {
           action: trackActions.click,
-          category: 'mercury-affiliate_search_posts',
+          category: 'affiliate_search_posts',
           label: `item-${parseInt(number, 10)}`,
         });
       }

--- a/app/components/post-search-results.js
+++ b/app/components/post-search-results.js
@@ -142,13 +142,13 @@ export default Component.extend(
       if (this.isInContent) {
         trackAffiliateUnit(this.unit, {
           action: trackActions.impression,
-          category: 'mercury-affiliate_incontent_posts',
+          category: 'affiliate_incontent_posts',
           label: 'affiliate_shown',
         });
       } else {
         trackAffiliateUnit(this.unit, {
           action: trackActions.impression,
-          category: 'mercury-affiliate_search_posts',
+          category: 'affiliate_search_posts',
           label: 'affiliate_shown',
         });
       }

--- a/app/components/post-search-results.js
+++ b/app/components/post-search-results.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { not } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
+import InViewportMixin from 'ember-in-viewport';
 import { getQueryString } from '@wikia/ember-fandom/utils/url';
 
 import { track, trackActions, trackAffiliateUnit } from '../utils/track';
@@ -23,125 +24,134 @@ function getAffiliateSlot(smallAffiliateUnit, posts) {
   return preferredIndex;
 }
 
-export default Component.extend({
-  fetchService: service('fetch'),
-  logger: service(),
-  wikiVariables: service(),
-  affiliateSlots: service(),
+export default Component.extend(
+  InViewportMixin,
+  {
+    fetchService: service('fetch'),
+    logger: service(),
+    wikiVariables: service(),
+    affiliateSlots: service(),
 
-  isLoading: true,
-  isCrossWiki: false,
-  posts: null,
-  unit: null,
-  debugAffiliateUnits: false,
-  isInContent: false,
+    isLoading: true,
+    isCrossWiki: false,
+    posts: null,
+    unit: null,
+    debugAffiliateUnits: false,
+    isInContent: false,
 
-  seeMoreButtonEnabled: not('isCrossWiki'),
+    seeMoreButtonEnabled: not('isCrossWiki'),
 
-  // fortunately we can compute the feeds path from articlePath (it has lang part)
-  seeMoreUrl: computed('wikiVariables.articlePath', function () {
-    return this.wikiVariables.articlePath.replace('/wiki/', '/f/');
-  }),
+    // fortunately we can compute the feeds path from articlePath (it has lang part)
+    seeMoreUrl: computed('wikiVariables.articlePath', function () {
+      return this.wikiVariables.articlePath.replace('/wiki/', '/f/');
+    }),
 
-  isEnabled: computed('wikiVariables.enableDiscussions', 'isCrossWiki', function () {
+    isEnabled: computed('wikiVariables.enableDiscussions', 'isCrossWiki', function () {
     // enabled on cross wiki and if community has discussions enabled
-    return this.isCrossWiki || this.get('wikiVariables.enableDiscussions');
-  }),
+      return this.isCrossWiki || this.get('wikiVariables.enableDiscussions');
+    }),
 
-  didInsertElement() {
-    this._super(...arguments);
+    didInsertElement() {
+      this._super(...arguments);
 
-    if (this.isEnabled) {
-      this.fetchResults(this.get('query'));
-    }
-  },
+      if (this.isEnabled) {
+        this.fetchResults(this.get('query'));
+      }
+    },
 
-  actions: {
-    trackMoreClick() {
-      track({
-        action: trackActions.click,
-        category: 'search_posts',
-        label: 'see-more',
+    actions: {
+      trackMoreClick() {
+        track({
+          action: trackActions.click,
+          category: 'search_posts',
+          label: 'see-more',
+        });
+      },
+    },
+
+    fetchResults(query) {
+      this.setProperties({
+        isLoading: true,
       });
+
+      const queryParams = {
+        query,
+        page: 0,
+        lang: this.wikiVariables.language.content,
+        limit: 3,
+      };
+
+      if (!this.isCrossWiki) {
+        queryParams.wikiId = this.wikiVariables.id;
+      }
+
+      const queryString = getQueryString(queryParams);
+
+      return this.fetchService.fetchFromUnifiedSearch(`/discussions-search${queryString}`)
+        .then(data => this.update(data))
+        .catch((e) => {
+          this.setProperties({
+            isLoading: false,
+            posts: null,
+          });
+          this.logger.error('Search request error', e);
+
+          return this;
+        });
+    },
+
+    update(state) {
+      if (!this.isDestroyed) {
+        const results = state.results.map(item => extend({}, item));
+
+        // check query param here
+        if (this.unit) {
+          const unit = this.unit;
+          const preferredIndex = getAffiliateSlot(unit, state.results);
+          results.splice(preferredIndex, 0, extend({}, unit, { type: 'affiliate' }));
+
+
+          if (results.length > 3) {
+            results.pop();
+          }
+        }
+
+        this.setProperties({
+          posts: results,
+          isLoading: false,
+        });
+
+        // make sure this is targeted
+        // only fire tracking when there are results
+        if (state.results.length) {
+          track({
+            action: trackActions.impression,
+            category: 'search_posts',
+            label: 'recent_posts_shown',
+          });
+        }
+      }
+
+      return this;
+    },
+    didEnterViewport() {
+      if (!this.unit) {
+        return;
+      }
+
+      if (this.isInContent) {
+        trackAffiliateUnit(this.unit, {
+          action: trackActions.impression,
+          category: 'mercury-affiliate_incontent_posts',
+          label: 'affiliate_shown',
+        });
+      } else {
+        trackAffiliateUnit(this.unit, {
+          action: trackActions.impression,
+          category: 'mercury-affiliate_search_posts',
+          label: 'affiliate_shown',
+        });
+      }
     },
   },
-
-  fetchResults(query) {
-    this.setProperties({
-      isLoading: true,
-    });
-
-    const queryParams = {
-      query,
-      page: 0,
-      lang: this.wikiVariables.language.content,
-      limit: 3,
-    };
-
-    if (!this.isCrossWiki) {
-      queryParams.wikiId = this.wikiVariables.id;
-    }
-
-    const queryString = getQueryString(queryParams);
-
-    return this.fetchService.fetchFromUnifiedSearch(`/discussions-search${queryString}`)
-      .then(data => this.update(data))
-      .catch((e) => {
-        this.setProperties({
-          isLoading: false,
-          posts: null,
-        });
-        this.logger.error('Search request error', e);
-
-        return this;
-      });
-  },
-
-  update(state) {
-    if (!this.isDestroyed) {
-      const results = state.results.map(item => extend({}, item));
-
-      // check query param here
-      if (this.unit) {
-        const unit = this.unit;
-        const preferredIndex = getAffiliateSlot(unit, state.results);
-        results.splice(preferredIndex, 0, extend({}, unit, { type: 'affiliate' }));
-
-        if (this.isInContent) {
-          trackAffiliateUnit(unit, {
-            action: trackActions.impression,
-            category: 'mercury-affiliate_incontent_posts',
-            label: 'affiliate_shown',
-          });
-        } else {
-          trackAffiliateUnit(unit, {
-            action: trackActions.impression,
-            category: 'mercury-affiliate_search_posts',
-            label: 'affiliate_shown',
-          });
-        }
-
-        if (results.length > 3) {
-          results.pop();
-        }
-      }
-
-      this.setProperties({
-        posts: results,
-        isLoading: false,
-      });
-
-      // make sure this is targeted
-      // only fire tracking when there are results
-      if (state.results.length) {
-        track({
-          action: trackActions.impression,
-          category: 'search_posts',
-          label: 'recent_posts_shown',
-        });
-      }
-    }
-
-    return this;
-  },
-});
+);

--- a/app/components/watch-show.js
+++ b/app/components/watch-show.js
@@ -2,11 +2,13 @@ import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { oneWay } from '@ember/object/computed';
 import { computed } from '@ember/object';
+import InViewportMixin from 'ember-in-viewport';
 import { track, trackActions } from '../utils/track';
 import { system } from '../utils/browser';
 import { isDarkTheme } from '../utils/mobile-app';
 
 export default Component.extend(
+  InViewportMixin,
   {
     wikiVariables: service(),
     geo: service(),
@@ -62,16 +64,6 @@ export default Component.extend(
     didInsertElement() {
       this._super(...arguments);
 
-      if (!this.isVisible) {
-        return;
-      }
-
-      track({
-        action: trackActions.impression,
-        category: 'article',
-        label: `watch-${this.wikiVariables.watchShowTrackingLabel || ''}`,
-      });
-
       if (this.trackingPixelURL) {
         const img = document.createElement('img');
 
@@ -81,6 +73,18 @@ export default Component.extend(
 
         document.body.appendChild(img);
       }
+    },
+
+    didEnterViewport() {
+      if (!this.isVisible) {
+        return;
+      }
+
+      track({
+        action: trackActions.impression,
+        category: 'article',
+        label: `watch-${this.wikiVariables.watchShowTrackingLabel || ''}`,
+      });
     },
 
     trackClick() {

--- a/app/components/watch-show.js
+++ b/app/components/watch-show.js
@@ -61,16 +61,6 @@ export default Component.extend(
       return isEnabled && isProperGeo && this.url && this.buttonLabel;
     }),
 
-    actions: {
-      trackClick() {
-        track({
-          action: trackActions.click,
-          category: 'article',
-          label: `watch-${this.wikiVariables.watchShowTrackingLabel || ''}`,
-        });
-      },
-    },
-
     didInsertElement() {
       this._super(...arguments);
 
@@ -85,8 +75,17 @@ export default Component.extend(
       }
     },
 
+    actions: {
+      trackClick() {
+        track({
+          action: trackActions.click,
+          category: 'article',
+          label: `watch-${this.wikiVariables.watchShowTrackingLabel || ''}`,
+        });
+      },
+    },
+
     didEnterViewport() {
-      debugger;
       if (!this.isVisible) {
         return;
       }

--- a/app/components/watch-show.js
+++ b/app/components/watch-show.js
@@ -61,6 +61,16 @@ export default Component.extend(
       return isEnabled && isProperGeo && this.url && this.buttonLabel;
     }),
 
+    actions: {
+      trackClick() {
+        track({
+          action: trackActions.click,
+          category: 'article',
+          label: `watch-${this.wikiVariables.watchShowTrackingLabel || ''}`,
+        });
+      },
+    },
+
     didInsertElement() {
       this._super(...arguments);
 
@@ -76,20 +86,13 @@ export default Component.extend(
     },
 
     didEnterViewport() {
+      debugger;
       if (!this.isVisible) {
         return;
       }
 
       track({
         action: trackActions.impression,
-        category: 'article',
-        label: `watch-${this.wikiVariables.watchShowTrackingLabel || ''}`,
-      });
-    },
-
-    trackClick() {
-      track({
-        action: trackActions.click,
         category: 'article',
         label: `watch-${this.wikiVariables.watchShowTrackingLabel || ''}`,
       });

--- a/app/services/affiliate-slots.js
+++ b/app/services/affiliate-slots.js
@@ -234,10 +234,8 @@ export default Service.extend({
           // fetch only the first unit if available
           return resolve(availableUnits.length > 0 ? availableUnits[0] : undefined);
         })
-        .catch((error) => {
-          // not raise anything
-          return resolve(undefined);
-        });
+        // not raise anything
+        .catch(() => resolve(undefined));
 
       return undefined;
     });
@@ -276,10 +274,8 @@ export default Service.extend({
           // fetch only the first unit if available
           return resolve(availableUnits.length > 0 ? availableUnits[0] : undefined);
         })
-        .catch((error) => {
-          // not raise anything
-          return resolve(undefined);
-        });
+        // not raise anything
+        .catch(() => resolve(undefined));
 
       return undefined;
     });

--- a/app/services/affiliate-slots.js
+++ b/app/services/affiliate-slots.js
@@ -235,8 +235,7 @@ export default Service.extend({
           return resolve(availableUnits.length > 0 ? availableUnits[0] : undefined);
         })
         .catch((error) => {
-          // log and do not raise anything
-          this.logger.error(error);
+          // not raise anything
           return resolve(undefined);
         });
 
@@ -278,8 +277,7 @@ export default Service.extend({
           return resolve(availableUnits.length > 0 ? availableUnits[0] : undefined);
         })
         .catch((error) => {
-          // log and do not raise anything
-          this.logger.error(error);
+          // not raise anything
           return resolve(undefined);
         });
 

--- a/app/templates/components/watch-show.hbs
+++ b/app/templates/components/watch-show.hbs
@@ -3,7 +3,7 @@
     <h2>{{cta}}</h2>
     <a
       class="wds-button"
-      onclick={{this.trackClick}}
+      onClick={{action "trackClick"}}
       href={{url}}
       target="_blank"
       rel="noopener"


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/CAKE-5282

## Description

* Use the incontent mixin to detect if the content is in the viewport
* Major lint change is required to the whole component. Use [this link](https://github.com/Wikia/mobile-wiki/pull/1891/files?utf8=%E2%9C%93&diff=unified&w=1) to look at the PR without whitespace changes

## Reviewers
@Wikia/cake 
