### PR TITLE
Prevent 'Watch Show' from appearing on top of content

### DIFF
--- a/app/components/portable-infobox.js
+++ b/app/components/portable-infobox.js
@@ -113,14 +113,14 @@ export default Component.extend(
 
     collapse() {
       this.set('collapsed', true);
-      this.element.style.height = `${this.collapsedHeight}px`;
-      this.element.querySelector('aside').style.height = `${this.collapsedHeight}px`;
+      this.element.querySelector('aside.portable-infobox').style.height = `${this.collapsedHeight}px`;
+      this.element.querySelector('.pi-expand-button').style.top = `${this.collapsedHeight}px`;
     },
 
     expand() {
       this.set('collapsed', false);
-      this.element.style.height = 'auto';
-      this.element.querySelector('aside').style.height = 'auto';
+      this.element.querySelector('aside.portable-infobox').style.height = 'auto';
+      this.element.querySelector('.pi-expand-button').style.top = 'auto';
     },
   },
 );

--- a/app/styles/module/article/_portable-infobox.scss
+++ b/app/styles/module/article/_portable-infobox.scss
@@ -50,9 +50,7 @@ $overflow-color: $wds-color-white;
   }
 
   &.collapsed ~ .pi-expand-button {
-    bottom: 0;
     box-shadow: none;
-    position: absolute;
 
     svg {
       transform: none;


### PR DESCRIPTION
## Links
* http://wikia-inc.atlassian.net/browse/CAKE-???

## Description
This fixes a bug caused by placing the 'Watch Now' module inside the portable infobox's wrapper (https://github.com/Wikia/mobile-wiki/pull/1873), which _that_ was done to fix another bug.

Summary of changes:
 * Remove `height` on wrapper element. It's not needed, only the infobox content's height needs to be limited.
 * Set the position of the "expand" button using `top` instead with the `collapsedHeight`.
 * Use a more specific query selector because `aside` is quite generic.
 * Remove `position: absolute` on the "expand" button state; this allows 'Watch Show' to appear below the button rather than underneath it.

## Reviewers
@Wikia/cake 