### PR TITLE
CAKE-5279 | [Nov 18] Enable affiliate units in Australia and New Zealand (with US copy)

### DIFF
--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -112,5 +112,167 @@
     "link": "https://disneyplus.bn5x.net/DrrRa",
     "country": ["US", "CA", "NL"],
     "isBig": true
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "disney",
+    "image": "https://static.wikia.nocookie.net/a136ba04-c922-40f2-89a6-f455b5ce895a",
+    "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
+    "subheading": "Watch Now On Disney+",
+    "link": "https://disneyplus.bn5x.net/DrrRa",
+    "country": [
+      "AU",
+      "NZ"
+    ],
+    "launchOn": "2019-11-18T22:00:00Z"
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "disney",
+    "image": "https://static.wikia.nocookie.net/a136ba04-c922-40f2-89a6-f455b5ce895a",
+    "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
+    "subheading": "Watch Now On Disney+",
+    "link": "https://disneyplus.bn5x.net/DrrRa",
+    "country": [
+      "AU",
+      "NZ"
+    ],
+    "isBig": true,
+    "launchOn": "2019-11-18T22:00:00Z"
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "mandalorian",
+    "image": "https://static.wikia.nocookie.net/a2ea4f98-6c5b-4cf3-9ee8-e58ec23ba686",
+    "heading": "A thrilling new adventure on the galactic frontier",
+    "subheading": "Watch Now On Disney+",
+    "link": "https://disneyplus.bn5x.net/333RX",
+    "country": [
+      "AU",
+      "NZ"
+    ],
+    "launchOn": "2019-11-18T22:00:00Z"
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "mandalorian",
+    "image": "https://static.wikia.nocookie.net/a2ea4f98-6c5b-4cf3-9ee8-e58ec23ba686",
+    "heading": "A thrilling new adventure on the galactic frontier",
+    "subheading": "Watch Now On Disney+",
+    "link": "https://disneyplus.bn5x.net/333RX",
+    "country": [
+      "AU",
+      "NZ"
+    ],
+    "isBig": true,
+    "launchOn": "2019-11-18T22:00:00Z"
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "marvel",
+    "image": "https://static.wikia.nocookie.net/d8374c50-15b4-4ee6-97be-fa8dc4d5976e",
+    "heading": "All Avengers, All the Time",
+    "subheading": "Watch Now On Disney+",
+    "link": "https://disneyplus.bn5x.net/beeqP",
+    "country": [
+      "AU",
+      "NZ"
+    ],
+    "launchOn": "2019-11-18T22:00:00Z"
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "marvel",
+    "image": "https://static.wikia.nocookie.net/d8374c50-15b4-4ee6-97be-fa8dc4d5976e",
+    "heading": "All Avengers, All the Time",
+    "subheading": "Watch Now On Disney+",
+    "link": "https://disneyplus.bn5x.net/beeqP",
+    "country": [
+      "AU",
+      "NZ"
+    ],
+    "isBig": true,
+    "launchOn": "2019-11-18T22:00:00Z"
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "pixar",
+    "image": "https://static.wikia.nocookie.net/5815ecac-01d2-4330-9116-887172ced2af",
+    "heading": "The Incredibles- a family who saves the world together sticks together",
+    "subheading": "Watch Now On Disney+",
+    "link": "https://disneyplus.bn5x.net/NVVXv",
+    "country": [
+      "AU",
+      "NZ"
+    ],
+    "launchOn": "2019-11-18T22:00:00Z"
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "pixar",
+    "image": "https://static.wikia.nocookie.net/5815ecac-01d2-4330-9116-887172ced2af",
+    "heading": "The Incredibles- a family who saves the world together sticks together",
+    "subheading": "Watch Now On Disney+",
+    "link": "https://disneyplus.bn5x.net/NVVXv",
+    "country": [
+      "AU",
+      "NZ"
+    ],
+    "isBig": true,
+    "launchOn": "2019-11-18T22:00:00Z"
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "starwars",
+    "image": "https://static.wikia.nocookie.net/29803c98-f93a-4291-bda3-8b44c8bbfcab",
+    "heading": "The Star Wars story lives forever",
+    "subheading": "Watch Now On Disney+",
+    "link": "https://disneyplus.bn5x.net/333RX",
+    "country": [
+      "AU",
+      "NZ"
+    ],
+    "launchOn": "2019-11-18T22:00:00Z"
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "starwars",
+    "image": "https://static.wikia.nocookie.net/29803c98-f93a-4291-bda3-8b44c8bbfcab",
+    "heading": "The Star Wars story lives forever",
+    "subheading": "Watch Now On Disney+",
+    "link": "https://disneyplus.bn5x.net/333RX",
+    "country": [
+      "AU",
+      "NZ"
+    ],
+    "isBig": true,
+    "launchOn": "2019-11-18T22:00:00Z"
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "simpsons",
+    "image": "https://static.wikia.nocookie.net/2d18111c-bc45-458f-9898-d2d4e3a50589",
+    "heading": "Don't have a cow man, relive the Simpsons",
+    "subheading": "Watch Now On Disney+",
+    "link": "https://disneyplus.bn5x.net/DrrRa",
+    "country": [
+      "AU",
+      "NZ"
+    ],
+    "launchOn": "2019-11-18T22:00:00Z"
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "simpsons",
+    "image": "https://static.wikia.nocookie.net/2d18111c-bc45-458f-9898-d2d4e3a50589",
+    "heading": "Don't have a cow man, relive the Simpsons",
+    "subheading": "Watch Now On Disney+",
+    "link": "https://disneyplus.bn5x.net/DrrRa",
+    "country": [
+      "AU",
+      "NZ"
+    ],
+    "isBig": true,
+    "launchOn": "2019-11-18T22:00:00Z"
   }
 ]

--- a/app/services/affiliate-slots.js
+++ b/app/services/affiliate-slots.js
@@ -57,9 +57,22 @@ const checkFilter = (filter, value) => (
 );
 
 /**
+ *  Returns `true` if `launchOn` is undefined, empty or in the past
+ *
+ * @param {AffiliateUnit} unit
+ * @returns {boolean}
+ */
+const checkLaunchOn = (unit) => (
+  typeof unit.launchOn === 'undefined'
+    || (typeof unit.launchOn === 'string'
+      && (filter.length === 0 || (Date.parse(unit.launchOn) < Date.now()))
+    )
+);
+
+/**
  * Check if the unit can be displayed on current system
  *
- * @param {string} unit
+ * @param {AffiliateUnit} unit
  * @returns {boolean}
  */
 const checkMobileSystem = (unit) => {
@@ -124,8 +137,10 @@ export default Service.extend({
     return units
       // check for mobile-system-specific units
       .filter(checkMobileSystem)
-      // filter targeting by GEO cookie (country)
+      // filter units by GEO cookie (country)
       .filter(u => checkFilter(u.country, this.currentCountry))
+      // filter units by `launchOn` if present
+      .filter(checkLaunchOn)
       // sort them according to the priority
       .sort((a, b) => ((a.priority > b.priority) ? 1 : -1));
   },

--- a/app/services/affiliate-slots.js
+++ b/app/services/affiliate-slots.js
@@ -1,4 +1,3 @@
-import { computed } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
 import Service, { inject as service } from '@ember/service';
 
@@ -62,10 +61,10 @@ const checkFilter = (filter, value) => (
  * @param {AffiliateUnit} unit
  * @returns {boolean}
  */
-const checkLaunchOn = (unit) => (
+const checkLaunchOn = unit => (
   typeof unit.launchOn === 'undefined'
     || (typeof unit.launchOn === 'string'
-      && (filter.length === 0 || (Date.parse(unit.launchOn) < Date.now()))
+      && (unit.launchOn.length === 0 || (Date.parse(unit.launchOn) < Date.now()))
     )
 );
 

--- a/app/services/affiliate-slots.md
+++ b/app/services/affiliate-slots.md
@@ -20,6 +20,7 @@ This file defines all the available affiliate units.
     "US",
     "NL"
   ],
+  "launchOn": "2018-01-01T00:00:00Z",
   "priority": 3,
   "disableOnSearch": false,
   "disableOnPage": false,
@@ -35,6 +36,7 @@ This file defines all the available affiliate units.
 * `category` - category name - this is being used in `affiliate-slots-targeting.json` file and in the taxonomy targeting
 * `isBig` - defaults to false. If set to true the unit will be tke over the post search results.
 * `isExternal` - defaults to false. If set to true the link is external and should be styled that way.
+* `launchOn` - a datetime of when the unit should be available
 * `priority` - a numerical priority. The higher the number, the more important unit is.
 * `disableOnSearch` - optional property. If set to true the unit is never going to be displayed on Search results.
 * `disableOnPage` - optional property. If set to true the unit is never going to be displayed on Pages results.


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/CAKE-5279

## Description

- Add `launchOn` to affiliate units
- Set up new units for AU and NZ

## Reviewers

@Wikia/cake 