### PR TITLE
IW | pass env property to fetch service config

### DIFF
--- a/app/services/affiliate-slots.js
+++ b/app/services/affiliate-slots.js
@@ -1,4 +1,3 @@
-import { computed } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
 import Service, { inject as service } from '@ember/service';
 

--- a/app/services/fetch.js
+++ b/app/services/fetch.js
@@ -10,6 +10,7 @@ export default fetch.extend({
       internalCache: this.runtimeConfig.internalCache,
       servicesExternalHost: this.runtimeConfig.servicesExternalHost,
       servicesInternalHost: this.runtimeConfig.servicesInternalHost,
+      wikiaEnv: this.runtimeConfig.wikiaEnv,
     };
 
     this._super(...arguments);


### PR DESCRIPTION
## Description

Pass environment to fetch service config. Without that, fastboot communicates with pandora services using ingress urls instead of k8s internal ones

## Reviewers

@Wikia/iwing 
