### PR TITLE
CAKE-5299 | Only client-side render for interrupt

### DIFF
--- a/app/components/post-search-interrupt.js
+++ b/app/components/post-search-interrupt.js
@@ -13,9 +13,8 @@ export default Component.extend({
 
   isEnabled: and('isBigFinished', 'isSmallFinished'),
 
-  init() {
+  didInsertElement() {
     this._super(...arguments);
-
 
     this.affiliateSlots.fetchUnitForSearch(this.query, false, this.debugAffiliateUnits)
       .then((unit) => {


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/CAKE-5299

## Description

- Use `didInsertElement` for interrupt, thus disabling interrupt in fastboot


## Reviewers

@Wikia/cake 
