### PR TITLE
CAKE-5313 Custom headings for affiliate units

### DIFF
--- a/app/components/affiliate-unit.js
+++ b/app/components/affiliate-unit.js
@@ -1,14 +1,25 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 import InViewportMixin from 'ember-in-viewport';
 import { trackAffiliateUnit, trackActions } from '../utils/track';
 
 export default Component.extend(
   InViewportMixin,
   {
+    i18n: service(),
+
     isInContent: false,
     unit: null,
 
     classNames: ['affiliate-unit'],
+
+    heading: computed('unit', function () {
+      if (this.unit && this.unit.tagline) {
+        return this.unit.tagline;
+      }
+      return this.i18n.t('affiliate-unit.big-unit-heading');
+    }),
 
     actions: {
       trackAffiliateClick() {

--- a/app/components/post-search-results.js
+++ b/app/components/post-search-results.js
@@ -31,6 +31,7 @@ export default Component.extend(
     logger: service(),
     wikiVariables: service(),
     affiliateSlots: service(),
+    i18n: service(),
 
     isLoading: true,
     isCrossWiki: false,
@@ -53,6 +54,13 @@ export default Component.extend(
 
     hasAffiliatePost: computed('posts', function () {
       return this.posts && this.posts.some(post => post.type === 'affiliate');
+    }),
+
+    heading: computed('unit', function () {
+      if (this.unit && this.unit.tagline) {
+        return this.unit.tagline;
+      }
+      return this.i18n.t('main.search-post-items-header');
     }),
 
     didInsertElement() {

--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -2,7 +2,7 @@
   {
     "campaign": "disneyplus",
     "category": "disney",
-    "tagline": "Recent Posts",
+    "tagline": "Related Posts",
     "image": "https://static.wikia.nocookie.net/a136ba04-c922-40f2-89a6-f455b5ce895a",
     "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
     "subheading": "Watch Now On Disney+",
@@ -23,7 +23,7 @@
   {
     "campaign": "disneyplus",
     "category": "mandalorian",
-    "tagline": "Recent Posts",
+    "tagline": "Related Posts",
     "image": "https://static.wikia.nocookie.net/a2ea4f98-6c5b-4cf3-9ee8-e58ec23ba686",
     "heading": "A thrilling new adventure on the galactic frontier",
     "subheading": "Watch Now On Disney+",
@@ -44,7 +44,7 @@
   {
     "campaign": "disneyplus",
     "category": "marvel",
-    "tagline": "Recent Posts",
+    "tagline": "Related Posts",
     "image": "https://static.wikia.nocookie.net/d8374c50-15b4-4ee6-97be-fa8dc4d5976e",
     "heading": "All Avengers, All the Time",
     "subheading": "Watch Now On Disney+",
@@ -65,7 +65,7 @@
   {
     "campaign": "disneyplus",
     "category": "pixar",
-    "tagline": "Recent Posts",
+    "tagline": "Related Posts",
     "image": "https://static.wikia.nocookie.net/5815ecac-01d2-4330-9116-887172ced2af",
     "heading": "The Incredibles- a family who saves the world together sticks together",
     "subheading": "Watch Now On Disney+",
@@ -86,7 +86,7 @@
   {
     "campaign": "disneyplus",
     "category": "starwars",
-    "tagline": "Recent Posts",
+    "tagline": "Related Posts",
     "image": "https://static.wikia.nocookie.net/29803c98-f93a-4291-bda3-8b44c8bbfcab",
     "heading": "The Star Wars story lives forever",
     "subheading": "Watch Now On Disney+",
@@ -107,7 +107,7 @@
   {
     "campaign": "disneyplus",
     "category": "simpsons",
-    "tagline": "Recent Posts",
+    "tagline": "Related Posts",
     "image": "https://static.wikia.nocookie.net/2d18111c-bc45-458f-9898-d2d4e3a50589",
     "heading": "Don't have a cow man, relive the Simpsons",
     "subheading": "Watch Now On Disney+",
@@ -128,7 +128,7 @@
   {
     "campaign": "disneyplus",
     "category": "disney",
-    "tagline": "Recent Posts",
+    "tagline": "Related Posts",
     "image": "https://static.wikia.nocookie.net/a136ba04-c922-40f2-89a6-f455b5ce895a",
     "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
     "subheading": "Watch Now On Disney+",
@@ -157,7 +157,7 @@
   {
     "campaign": "disneyplus",
     "category": "mandalorian",
-    "tagline": "Recent Posts",
+    "tagline": "Related Posts",
     "image": "https://static.wikia.nocookie.net/a2ea4f98-6c5b-4cf3-9ee8-e58ec23ba686",
     "heading": "A thrilling new adventure on the galactic frontier",
     "subheading": "Watch Now On Disney+",
@@ -186,7 +186,7 @@
   {
     "campaign": "disneyplus",
     "category": "marvel",
-    "tagline": "Recent Posts",
+    "tagline": "Related Posts",
     "image": "https://static.wikia.nocookie.net/d8374c50-15b4-4ee6-97be-fa8dc4d5976e",
     "heading": "All Avengers, All the Time",
     "subheading": "Watch Now On Disney+",
@@ -215,7 +215,7 @@
   {
     "campaign": "disneyplus",
     "category": "pixar",
-    "tagline": "Recent Posts",
+    "tagline": "Related Posts",
     "image": "https://static.wikia.nocookie.net/5815ecac-01d2-4330-9116-887172ced2af",
     "heading": "The Incredibles- a family who saves the world together sticks together",
     "subheading": "Watch Now On Disney+",
@@ -244,7 +244,7 @@
   {
     "campaign": "disneyplus",
     "category": "starwars",
-    "tagline": "Recent Posts",
+    "tagline": "Related Posts",
     "image": "https://static.wikia.nocookie.net/29803c98-f93a-4291-bda3-8b44c8bbfcab",
     "heading": "The Star Wars story lives forever",
     "subheading": "Watch Now On Disney+",
@@ -273,7 +273,7 @@
   {
     "campaign": "disneyplus",
     "category": "simpsons",
-    "tagline": "Recent Posts",
+    "tagline": "Related Posts",
     "image": "https://static.wikia.nocookie.net/2d18111c-bc45-458f-9898-d2d4e3a50589",
     "heading": "Don't have a cow man, relive the Simpsons",
     "subheading": "Watch Now On Disney+",

--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -2,6 +2,7 @@
   {
     "campaign": "disneyplus",
     "category": "disney",
+    "tagline": "Recent Posts",
     "image": "https://static.wikia.nocookie.net/a136ba04-c922-40f2-89a6-f455b5ce895a",
     "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
     "subheading": "Watch Now On Disney+",
@@ -11,6 +12,7 @@
   {
     "campaign": "disneyplus",
     "category": "disney",
+    "tagline": "Suggested For You",
     "image": "https://static.wikia.nocookie.net/a136ba04-c922-40f2-89a6-f455b5ce895a",
     "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
     "subheading": "Watch Now On Disney+",
@@ -21,6 +23,7 @@
   {
     "campaign": "disneyplus",
     "category": "mandalorian",
+    "tagline": "Recent Posts",
     "image": "https://static.wikia.nocookie.net/a2ea4f98-6c5b-4cf3-9ee8-e58ec23ba686",
     "heading": "A thrilling new adventure on the galactic frontier",
     "subheading": "Watch Now On Disney+",
@@ -30,6 +33,7 @@
   {
     "campaign": "disneyplus",
     "category": "mandalorian",
+    "tagline": "Suggested For You",
     "image": "https://static.wikia.nocookie.net/a2ea4f98-6c5b-4cf3-9ee8-e58ec23ba686",
     "heading": "A thrilling new adventure on the galactic frontier",
     "subheading": "Watch Now On Disney+",
@@ -40,6 +44,7 @@
   {
     "campaign": "disneyplus",
     "category": "marvel",
+    "tagline": "Recent Posts",
     "image": "https://static.wikia.nocookie.net/d8374c50-15b4-4ee6-97be-fa8dc4d5976e",
     "heading": "All Avengers, All the Time",
     "subheading": "Watch Now On Disney+",
@@ -49,6 +54,7 @@
   {
     "campaign": "disneyplus",
     "category": "marvel",
+    "tagline": "Suggested For You",
     "image": "https://static.wikia.nocookie.net/d8374c50-15b4-4ee6-97be-fa8dc4d5976e",
     "heading": "All Avengers, All the Time",
     "subheading": "Watch Now On Disney+",
@@ -59,6 +65,7 @@
   {
     "campaign": "disneyplus",
     "category": "pixar",
+    "tagline": "Recent Posts",
     "image": "https://static.wikia.nocookie.net/5815ecac-01d2-4330-9116-887172ced2af",
     "heading": "The Incredibles- a family who saves the world together sticks together",
     "subheading": "Watch Now On Disney+",
@@ -68,6 +75,7 @@
   {
     "campaign": "disneyplus",
     "category": "pixar",
+    "tagline": "Suggested For You",
     "image": "https://static.wikia.nocookie.net/5815ecac-01d2-4330-9116-887172ced2af",
     "heading": "The Incredibles- a family who saves the world together sticks together",
     "subheading": "Watch Now On Disney+",
@@ -78,6 +86,7 @@
   {
     "campaign": "disneyplus",
     "category": "starwars",
+    "tagline": "Recent Posts",
     "image": "https://static.wikia.nocookie.net/29803c98-f93a-4291-bda3-8b44c8bbfcab",
     "heading": "The Star Wars story lives forever",
     "subheading": "Watch Now On Disney+",
@@ -87,6 +96,7 @@
   {
     "campaign": "disneyplus",
     "category": "starwars",
+    "tagline": "Suggested For You",
     "image": "https://static.wikia.nocookie.net/29803c98-f93a-4291-bda3-8b44c8bbfcab",
     "heading": "The Star Wars story lives forever",
     "subheading": "Watch Now On Disney+",
@@ -97,6 +107,7 @@
   {
     "campaign": "disneyplus",
     "category": "simpsons",
+    "tagline": "Recent Posts",
     "image": "https://static.wikia.nocookie.net/2d18111c-bc45-458f-9898-d2d4e3a50589",
     "heading": "Don't have a cow man, relive the Simpsons",
     "subheading": "Watch Now On Disney+",
@@ -106,6 +117,7 @@
   {
     "campaign": "disneyplus",
     "category": "simpsons",
+    "tagline": "Suggested For You",
     "image": "https://static.wikia.nocookie.net/2d18111c-bc45-458f-9898-d2d4e3a50589",
     "heading": "Don't have a cow man, relive the Simpsons",
     "subheading": "Watch Now On Disney+",
@@ -116,6 +128,7 @@
   {
     "campaign": "disneyplus",
     "category": "disney",
+    "tagline": "Recent Posts",
     "image": "https://static.wikia.nocookie.net/a136ba04-c922-40f2-89a6-f455b5ce895a",
     "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
     "subheading": "Watch Now On Disney+",
@@ -129,6 +142,7 @@
   {
     "campaign": "disneyplus",
     "category": "disney",
+    "tagline": "Suggested For You",
     "image": "https://static.wikia.nocookie.net/a136ba04-c922-40f2-89a6-f455b5ce895a",
     "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
     "subheading": "Watch Now On Disney+",
@@ -143,6 +157,7 @@
   {
     "campaign": "disneyplus",
     "category": "mandalorian",
+    "tagline": "Recent Posts",
     "image": "https://static.wikia.nocookie.net/a2ea4f98-6c5b-4cf3-9ee8-e58ec23ba686",
     "heading": "A thrilling new adventure on the galactic frontier",
     "subheading": "Watch Now On Disney+",
@@ -156,6 +171,7 @@
   {
     "campaign": "disneyplus",
     "category": "mandalorian",
+    "tagline": "Suggested For You",
     "image": "https://static.wikia.nocookie.net/a2ea4f98-6c5b-4cf3-9ee8-e58ec23ba686",
     "heading": "A thrilling new adventure on the galactic frontier",
     "subheading": "Watch Now On Disney+",
@@ -170,6 +186,7 @@
   {
     "campaign": "disneyplus",
     "category": "marvel",
+    "tagline": "Recent Posts",
     "image": "https://static.wikia.nocookie.net/d8374c50-15b4-4ee6-97be-fa8dc4d5976e",
     "heading": "All Avengers, All the Time",
     "subheading": "Watch Now On Disney+",
@@ -183,6 +200,7 @@
   {
     "campaign": "disneyplus",
     "category": "marvel",
+    "tagline": "Suggested For You",
     "image": "https://static.wikia.nocookie.net/d8374c50-15b4-4ee6-97be-fa8dc4d5976e",
     "heading": "All Avengers, All the Time",
     "subheading": "Watch Now On Disney+",
@@ -197,6 +215,7 @@
   {
     "campaign": "disneyplus",
     "category": "pixar",
+    "tagline": "Recent Posts",
     "image": "https://static.wikia.nocookie.net/5815ecac-01d2-4330-9116-887172ced2af",
     "heading": "The Incredibles- a family who saves the world together sticks together",
     "subheading": "Watch Now On Disney+",
@@ -210,6 +229,7 @@
   {
     "campaign": "disneyplus",
     "category": "pixar",
+    "tagline": "Suggested For You",
     "image": "https://static.wikia.nocookie.net/5815ecac-01d2-4330-9116-887172ced2af",
     "heading": "The Incredibles- a family who saves the world together sticks together",
     "subheading": "Watch Now On Disney+",
@@ -224,6 +244,7 @@
   {
     "campaign": "disneyplus",
     "category": "starwars",
+    "tagline": "Recent Posts",
     "image": "https://static.wikia.nocookie.net/29803c98-f93a-4291-bda3-8b44c8bbfcab",
     "heading": "The Star Wars story lives forever",
     "subheading": "Watch Now On Disney+",
@@ -237,6 +258,7 @@
   {
     "campaign": "disneyplus",
     "category": "starwars",
+    "tagline": "Suggested For You",
     "image": "https://static.wikia.nocookie.net/29803c98-f93a-4291-bda3-8b44c8bbfcab",
     "heading": "The Star Wars story lives forever",
     "subheading": "Watch Now On Disney+",
@@ -251,6 +273,7 @@
   {
     "campaign": "disneyplus",
     "category": "simpsons",
+    "tagline": "Recent Posts",
     "image": "https://static.wikia.nocookie.net/2d18111c-bc45-458f-9898-d2d4e3a50589",
     "heading": "Don't have a cow man, relive the Simpsons",
     "subheading": "Watch Now On Disney+",
@@ -264,6 +287,7 @@
   {
     "campaign": "disneyplus",
     "category": "simpsons",
+    "tagline": "Suggested For You",
     "image": "https://static.wikia.nocookie.net/2d18111c-bc45-458f-9898-d2d4e3a50589",
     "heading": "Don't have a cow man, relive the Simpsons",
     "subheading": "Watch Now On Disney+",

--- a/app/services/affiliate-slots.md
+++ b/app/services/affiliate-slots.md
@@ -11,6 +11,7 @@ This file defines all the available affiliate units.
   "campaign": "disneyplus",
   "category": "disney",
   "isBig": false,
+  "tagline": "Suggested For You",
   "image": "https://vignette.wikia.nocookie.net/central/images/b/bc/Wiki.png/revision/latest?cb=20180423162614",
   "heading": "Fandom",
   "subheading": "Check this out",
@@ -35,6 +36,7 @@ This file defines all the available affiliate units.
 * `campaign` - campaing name - this is being used in `affiliate-slots-targeting.json` file and in the taxonomy targeting
 * `category` - category name - this is being used in `affiliate-slots-targeting.json` file and in the taxonomy targeting
 * `isBig` - defaults to false. If set to true the unit will be tke over the post search results.
+* `tagline` - title heading above the unit
 * `isExternal` - defaults to false. If set to true the link is external and should be styled that way.
 * `launchOn` - a datetime of when the unit should be available
 * `priority` - a numerical priority. The higher the number, the more important unit is.

--- a/app/templates/components/affiliate-unit.hbs
+++ b/app/templates/components/affiliate-unit.hbs
@@ -3,7 +3,7 @@
 </div>
 <div class="affiliate-unit__header wds-font-weight-medium wds-midlight-navy">
   <Icon @name="user" @size="small" class="affiliate-unit__header-icon" />
-  {{i18n "affiliate-unit.big-unit-heading"}}
+  {{heading}}
 </div>
 <a
   href={{unit.link}}

--- a/app/templates/components/post-search-results.hbs
+++ b/app/templates/components/post-search-results.hbs
@@ -8,7 +8,7 @@
     <header class="post-search-results__header">
       <div class="post-search-results__header-text wds-midlight-navy">
         <Icon @name="comment" @size="small" />
-        {{{i18n "main.search-post-items-header" ns="search"}}}
+        {{heading}}
       </div>
       {{#if seeMoreButtonEnabled}}
         <Button


### PR DESCRIPTION
## Links
* http://wikia-inc.atlassian.net/browse/CAKE-5313

## Description
Allow a custom heading/tagline to override the default for both types of affiliate units.

## Reviewers
@Wikia/cake 