### PR TITLE
cake-5302 | Add logic to display disclaimer

### DIFF
--- a/app/components/affiliate-unit.js
+++ b/app/components/affiliate-unit.js
@@ -10,6 +10,8 @@ export default Component.extend(
 
     classNames: ['affiliate-unit'],
 
+    showAffiiateUnitDisclaimer: document.querySelector('.watch-show__disclaimer') ? false : true,
+
     actions: {
       trackAffiliateClick() {
         trackAffiliateUnit(this.unit, {

--- a/app/components/affiliate-unit.js
+++ b/app/components/affiliate-unit.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import InViewportMixin from 'ember-in-viewport';
+import exists from '../utils/exists';
 import { trackAffiliateUnit, trackActions } from '../utils/track';
 
 export default Component.extend(
@@ -10,7 +11,7 @@ export default Component.extend(
 
     classNames: ['affiliate-unit'],
 
-    showAffiiateUnitDisclaimer: document.querySelector('.watch-show__disclaimer') ? false : true,
+    showAffiiateUnitDisclaimer: !exists('.watch-show__disclaimer'),
 
     actions: {
       trackAffiliateClick() {

--- a/app/components/post-search-results.js
+++ b/app/components/post-search-results.js
@@ -51,6 +51,13 @@ export default Component.extend(
       return this.isCrossWiki || this.get('wikiVariables.enableDiscussions');
     }),
 
+    showPostSearchResultsDisclaimer: computed('posts', function () {
+      const isWSDisclaimer = document.querySelector('.watch-show__disclaimer');
+      const isAffiliateDisclaimer = document.querySelector('.affiliate-unit__disclaimer');
+
+      return this.hasAffiliatePost && !isWSDisclaimer && !isAffiliateDisclaimer;
+    }),
+
     hasAffiliatePost: computed('posts', function () {
       return this.posts && this.posts.some(post => post.type === 'affiliate');
     }),

--- a/app/components/post-search-results.js
+++ b/app/components/post-search-results.js
@@ -6,6 +6,7 @@ import InViewportMixin from 'ember-in-viewport';
 import { getQueryString } from '@wikia/ember-fandom/utils/url';
 
 import { track, trackActions, trackAffiliateUnit } from '../utils/track';
+import exists from '../utils/exists';
 import extend from '../utils/extend';
 
 const DEFAULT_AFFILIATE_SLOT = 1;
@@ -52,8 +53,8 @@ export default Component.extend(
     }),
 
     showPostSearchResultsDisclaimer: computed('posts', function () {
-      const isWSDisclaimer = document.querySelector('.watch-show__disclaimer');
-      const isAffiliateDisclaimer = document.querySelector('.affiliate-unit__disclaimer');
+      const isWSDisclaimer = exists('.watch-show__disclaimer');
+      const isAffiliateDisclaimer = exists('.affiliate-unit__disclaimer');
 
       return this.hasAffiliatePost && !isWSDisclaimer && !isAffiliateDisclaimer;
     }),

--- a/app/templates/components/affiliate-unit.hbs
+++ b/app/templates/components/affiliate-unit.hbs
@@ -14,7 +14,9 @@
     <div class="affiliate-unit__subheading wds-font-weight-bold">{{unit.subheading}}</div>
   </div>
 </a>
-<div class="affiliate-unit__disclaimer">
-  {{i18n "affiliate-unit.disclaimer"}}
-</div>
+{{#if showAffiiateUnitDisclaimer}}
+  <div class="affiliate-unit__disclaimer">
+    {{i18n "affiliate-unit.disclaimer"}}
+  </div>
+{{/if}}
 <div class="affiliate-unit__slant"></div>

--- a/app/templates/components/post-search-results.hbs
+++ b/app/templates/components/post-search-results.hbs
@@ -45,7 +45,7 @@
         {{/each}}
       </div>
     {{/if}}
-    {{#if hasAffiliatePost}}
+    {{#if showPostSearchResultsDisclaimer}}
       <div class="post-search-results__disclaimer">
         {{i18n "affiliate-unit.disclaimer"}}
       </div>

--- a/app/utils/exists.js
+++ b/app/utils/exists.js
@@ -1,0 +1,4 @@
+export default function exists(selector) {
+  const el = document.querySelector(selector);
+  return !!el;
+}


### PR DESCRIPTION
## Links

* [Parent Ticket](http://wikia-inc.atlassian.net/browse/CAKE-5293)

## Description

Logic rules for displaying affiliate unit disclaimer:
1. Should always show at top when Watch Show Module is present
2. If Watch Show module isn't present, show on the first affiliate unit
3. Display on search results affiliate unit.

## Reviewers

@Wikia/cake 
@mklucsarits 
