### PR TITLE
IW | Remove --disable-gpu Chrome flag when running tests

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -16,7 +16,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',


### PR DESCRIPTION
Chrome >=77 will crash with the `--disable-gpu` flag present. This PR removes it.