### PR TITLE
cake-5318 | Add logic for rendering updated affiliate links

### DIFF
--- a/app/components/affiliate-unit.js
+++ b/app/components/affiliate-unit.js
@@ -23,15 +23,13 @@ export default Component.extend(
       return this.i18n.t('affiliate-unit.big-unit-heading');
     }),
 
-    getUnitLink: computed('link', function () {
-      let unitLink = this.unit.link;
-
-      if (this.isInContent && this.unit.links.page) {
-        unitLink = this.unit.links.page;
-      } else if (this.unit.links.search) {
-        unitLink = this.unit.links.search;
+    getUnitLink: computed('unit', 'isInContent', function () {
+      if (this.isInContent && this.unit.links && this.unit.links.article) {
+        this.unit.link = this.unit.links.article;
+      } else if (this.unit.links && this.unit.links.search) {
+        this.unit.link = this.unit.links.search;
       }
-      return unitLink;
+      return this.unit.link;
     }),
 
     actions: {

--- a/app/components/affiliate-unit.js
+++ b/app/components/affiliate-unit.js
@@ -23,6 +23,17 @@ export default Component.extend(
       return this.i18n.t('affiliate-unit.big-unit-heading');
     }),
 
+    getUnitLink: computed('link', function () {
+      let unitLink = this.unit.link;
+
+      if (this.isInContent && this.unit.links.page) {
+        unitLink = this.unit.links.page;
+      } else if (this.unit.links.search) {
+        unitLink = this.unit.links.search;
+      }
+      return unitLink;
+    }),
+
     actions: {
       trackAffiliateClick() {
         trackAffiliateUnit(this.unit, {

--- a/app/components/affiliate-unit.js
+++ b/app/components/affiliate-unit.js
@@ -26,7 +26,7 @@ export default Component.extend(
     getUnitLink: computed('unit', 'isInContent', function () {
       if (this.isInContent && this.unit.links && this.unit.links.article) {
         this.unit.link = this.unit.links.article;
-      } else if (this.unit.links && this.unit.links.search) {
+      } else if (!this.isInContent && this.unit.links && this.unit.links.search) {
         this.unit.link = this.unit.links.search;
       }
       return this.unit.link;

--- a/app/components/post-search-results-affiliate-item.js
+++ b/app/components/post-search-results-affiliate-item.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 import { trackActions, trackAffiliateUnit } from '../utils/track';
 
@@ -6,6 +7,17 @@ export default Component.extend({
   isInContent: false,
 
   classNames: ['post-search-results-affiliate-item'],
+
+  getUnitLink: computed('link', function () {
+    let unitLink = this.affiliateUnit.link;
+
+    if (this.isInContent && this.affiliateUnit.links.page) {
+      unitLink = this.affiliateUnit.links.page;
+    } else if (this.affiliateUnit.links.search) {
+      unitLink = this.affiliateUnit.links.search;
+    }
+    return unitLink;
+  }),
 
   actions: {
     trackClick(number, unit) {

--- a/app/components/post-search-results-affiliate-item.js
+++ b/app/components/post-search-results-affiliate-item.js
@@ -8,15 +8,13 @@ export default Component.extend({
 
   classNames: ['post-search-results-affiliate-item'],
 
-  getUnitLink: computed('link', function () {
-    let unitLink = this.affiliateUnit.link;
-
-    if (this.isInContent && this.affiliateUnit.links.page) {
-      unitLink = this.affiliateUnit.links.page;
-    } else if (this.affiliateUnit.links.search) {
-      unitLink = this.affiliateUnit.links.search;
+  getUnitLink: computed('unit', 'isInContent', function () {
+    if (this.isInContent && this.affiliateUnit.links && this.affiliateUnit.links.article) {
+      this.affiliateUnit.link = this.affiliateUnit.links.article;
+    } else if (!this.isInContent && this.affiliateUnit.links && this.affiliateUnit.links.search) {
+      this.affiliateUnit.link = this.affiliateUnit.links.search;
     }
-    return unitLink;
+    return this.affiliateUnit.link;
   }),
 
   actions: {

--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -11,7 +11,7 @@
       "article": "https://www.fandom.com/article-3",
       "search": "https://www.fandom.com/search-3"
     },
-    "country": ["US", "CA", "NL"]
+    "country": ["US", "CA", "NL", "AU", "NZ"]
   },
   {
     "campaign": "test",
@@ -25,7 +25,7 @@
       "article": "https://www.fandom.com/article-1",
       "search": "https://www.fandom.com/search-1"
     },
-    "country": ["US", "CA", "NL"],
+    "country": ["US", "CA", "NL", "AU", "NZ"],
     "isBig": true
   },
   {
@@ -40,7 +40,7 @@
       "article": "https://disneyplus.bn5x.net/qq5qq",
       "search": "https://disneyplus.bn5x.net/NV1DP"
     },
-    "country": ["US", "CA", "NL"]
+    "country": ["US", "CA", "NL", "AU", "NZ"]
   },
   {
     "campaign": "disneyplus",
@@ -54,7 +54,7 @@
       "article": "https://disneyplus.bn5x.net/23b9G",
       "search": "https://disneyplus.bn5x.net/vrG3W"
     },
-    "country": ["US", "CA", "NL"],
+    "country": ["US", "CA", "NL", "AU", "NZ"],
     "isBig": true
   },
   {
@@ -69,7 +69,7 @@
       "article": "https://disneyplus.bn5x.net/PZJZM",
       "search": "https://disneyplus.bn5x.net/xPV33"
     },
-    "country": ["US", "CA", "NL"]
+    "country": ["US", "CA", "NL", "AU", "NZ"]
   },
   {
     "campaign": "disneyplus",
@@ -83,7 +83,7 @@
       "article": "https://disneyplus.bn5x.net/dANAy",
       "search": "https://disneyplus.bn5x.net/mB93y"
     },
-    "country": ["US", "CA", "NL"],
+    "country": ["US", "CA", "NL", "AU", "NZ"],
     "isBig": true
   },
   {
@@ -98,7 +98,7 @@
       "article": "https://disneyplus.bn5x.net/9343Y",
       "search": "https://disneyplus.bn5x.net/qq53q"
     },
-    "country": ["US", "CA", "NL"]
+    "country": ["US", "CA", "NL", "AU", "NZ"]
   },
   {
     "campaign": "disneyplus",
@@ -112,7 +112,7 @@
       "article": "https://disneyplus.bn5x.net/vrGrN",
       "search": "https://disneyplus.bn5x.net/77RrV"
     },
-    "country": ["US", "CA", "NL"],
+    "country": ["US", "CA", "NL", "AU", "NZ"],
     "isBig": true
   },
   {
@@ -127,7 +127,7 @@
       "article": "https://disneyplus.bn5x.net/Dr9rG",
       "search": "https://disneyplus.bn5x.net/LGAq3"
     },
-    "country": ["US", "CA", "NL"]
+    "country": ["US", "CA", "NL", "AU", "NZ"]
   },
   {
     "campaign": "disneyplus",
@@ -141,7 +141,7 @@
       "article": "https://disneyplus.bn5x.net/RXgXy",
       "search": "https://disneyplus.bn5x.net/KAaLv"
     },
-    "country": ["US", "CA", "NL"],
+    "country": ["US", "CA", "NL", "AU", "NZ"],
     "isBig": true
   },
   {
@@ -156,7 +156,7 @@
       "article": "https://disneyplus.bn5x.net/PZJZM",
       "search": "https://disneyplus.bn5x.net/xPV33"
     },
-    "country": ["US", "CA", "NL"]
+    "country": ["US", "CA", "NL", "AU", "NZ"]
   },
   {
     "campaign": "disneyplus",
@@ -170,7 +170,7 @@
       "article": "https://disneyplus.bn5x.net/dANAy",
       "search": "https://disneyplus.bn5x.net/mB93y"
     },
-    "country": ["US", "CA", "NL"],
+    "country": ["US", "CA", "NL", "AU", "NZ"],
     "isBig": true
   },
   {
@@ -185,7 +185,7 @@
       "article": "https://disneyplus.bn5x.net/qq5qq",
       "search": "https://disneyplus.bn5x.net/NV1DP"
     },
-    "country": ["US", "CA", "NL"]
+    "country": ["US", "CA", "NL", "AU", "NZ"]
   },
   {
     "campaign": "disneyplus",
@@ -199,229 +199,7 @@
       "article": "https://disneyplus.bn5x.net/23b9G",
       "search": "https://disneyplus.bn5x.net/vrG3W"
     },
-    "country": ["US", "CA", "NL"],
+    "country": ["US", "CA", "NL", "AU", "NZ"],
     "isBig": true
-  },
-  {
-    "campaign": "disneyplus",
-    "category": "disney",
-    "tagline": "Related Posts",
-    "image": "https://static.wikia.nocookie.net/a136ba04-c922-40f2-89a6-f455b5ce895a",
-    "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
-    "subheading": "Watch Now On Disney+",
-    "link": "https://disneyplus.bn5x.net/DrrRa",
-    "links": {
-      "article": "https://disneyplus.bn5x.net/qq5qq",
-      "search": "https://disneyplus.bn5x.net/NV1DP"
-    },
-    "country": [
-      "AU",
-      "NZ"
-    ],
-    "launchOn": "2019-11-18T22:00:00Z"
-  },
-  {
-    "campaign": "disneyplus",
-    "category": "disney",
-    "tagline": "Suggested For You",
-    "image": "https://static.wikia.nocookie.net/a136ba04-c922-40f2-89a6-f455b5ce895a",
-    "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
-    "subheading": "Watch Now On Disney+",
-    "link": "https://disneyplus.bn5x.net/DrrRa",
-    "links": {
-      "article": "https://disneyplus.bn5x.net/23b9G",
-      "search": "https://disneyplus.bn5x.net/vrG3W"
-    },
-    "country": [
-      "AU",
-      "NZ"
-    ],
-    "isBig": true,
-    "launchOn": "2019-11-18T22:00:00Z"
-  },
-  {
-    "campaign": "disneyplus",
-    "category": "mandalorian",
-    "tagline": "Related Posts",
-    "image": "https://static.wikia.nocookie.net/a2ea4f98-6c5b-4cf3-9ee8-e58ec23ba686",
-    "heading": "A thrilling new adventure on the galactic frontier",
-    "subheading": "Watch Now On Disney+",
-    "link": "https://disneyplus.bn5x.net/333RX",
-    "links": {
-      "article": "https://disneyplus.bn5x.net/PZJZM",
-      "search": "https://disneyplus.bn5x.net/xPV33"
-    },
-    "country": [
-      "AU",
-      "NZ"
-    ],
-    "launchOn": "2019-11-18T22:00:00Z"
-  },
-  {
-    "campaign": "disneyplus",
-    "category": "mandalorian",
-    "tagline": "Suggested For You",
-    "image": "https://static.wikia.nocookie.net/a2ea4f98-6c5b-4cf3-9ee8-e58ec23ba686",
-    "heading": "A thrilling new adventure on the galactic frontier",
-    "subheading": "Watch Now On Disney+",
-    "link": "https://disneyplus.bn5x.net/333RX",
-    "links": {
-      "article": "https://disneyplus.bn5x.net/dANAy",
-      "search": "https://disneyplus.bn5x.net/mB93y"
-    },
-    "country": [
-      "AU",
-      "NZ"
-    ],
-    "isBig": true,
-    "launchOn": "2019-11-18T22:00:00Z"
-  },
-  {
-    "campaign": "disneyplus",
-    "category": "marvel",
-    "tagline": "Related Posts",
-    "image": "https://static.wikia.nocookie.net/d8374c50-15b4-4ee6-97be-fa8dc4d5976e",
-    "heading": "All Avengers, All the Time",
-    "subheading": "Watch Now On Disney+",
-    "link": "https://disneyplus.bn5x.net/YxZKm",
-    "links": {
-      "article": "https://disneyplus.bn5x.net/9343Y",
-      "search": "https://disneyplus.bn5x.net/qq53q"
-    },
-    "country": [
-      "AU",
-      "NZ"
-    ],
-    "launchOn": "2019-11-18T22:00:00Z"
-  },
-  {
-    "campaign": "disneyplus",
-    "category": "marvel",
-    "tagline": "Suggested For You",
-    "image": "https://static.wikia.nocookie.net/d8374c50-15b4-4ee6-97be-fa8dc4d5976e",
-    "heading": "All Avengers, All the Time",
-    "subheading": "Watch Now On Disney+",
-    "link": "https://disneyplus.bn5x.net/YxZKm",
-    "links": {
-      "article": "https://disneyplus.bn5x.net/vrGrN",
-      "search": "https://disneyplus.bn5x.net/77RrV"
-    },
-    "country": [
-      "AU",
-      "NZ"
-    ],
-    "isBig": true,
-    "launchOn": "2019-11-18T22:00:00Z"
-  },
-  {
-    "campaign": "disneyplus",
-    "category": "pixar",
-    "tagline": "Related Posts",
-    "image": "https://static.wikia.nocookie.net/5815ecac-01d2-4330-9116-887172ced2af",
-    "heading": "The Incredibles- a family who saves the world together sticks together",
-    "subheading": "Watch Now On Disney+",
-    "link": "https://disneyplus.bn5x.net/NVVXv",
-    "links": {
-      "article": "https://disneyplus.bn5x.net/Dr9rG",
-      "search": "https://disneyplus.bn5x.net/LGAq3"
-    },
-    "country": [
-      "AU",
-      "NZ"
-    ],
-    "launchOn": "2019-11-18T22:00:00Z"
-  },
-  {
-    "campaign": "disneyplus",
-    "category": "pixar",
-    "tagline": "Suggested For You",
-    "image": "https://static.wikia.nocookie.net/5815ecac-01d2-4330-9116-887172ced2af",
-    "heading": "The Incredibles- a family who saves the world together sticks together",
-    "subheading": "Watch Now On Disney+",
-    "link": "https://disneyplus.bn5x.net/NVVXv",
-    "links": {
-      "article": "https://disneyplus.bn5x.net/RXgXy",
-      "search": "https://disneyplus.bn5x.net/KAaLv"
-    },
-    "country": [
-      "AU",
-      "NZ"
-    ],
-    "isBig": true,
-    "launchOn": "2019-11-18T22:00:00Z"
-  },
-  {
-    "campaign": "disneyplus",
-    "category": "starwars",
-    "tagline": "Related Posts",
-    "image": "https://static.wikia.nocookie.net/29803c98-f93a-4291-bda3-8b44c8bbfcab",
-    "heading": "The Star Wars story lives forever",
-    "subheading": "Watch Now On Disney+",
-    "link": "https://disneyplus.bn5x.net/333RX",
-    "links": {
-      "article": "https://disneyplus.bn5x.net/PZJZM",
-      "search": "https://disneyplus.bn5x.net/xPV33"
-    },
-    "country": [
-      "AU",
-      "NZ"
-    ],
-    "launchOn": "2019-11-18T22:00:00Z"
-  },
-  {
-    "campaign": "disneyplus",
-    "category": "starwars",
-    "tagline": "Suggested For You",
-    "image": "https://static.wikia.nocookie.net/29803c98-f93a-4291-bda3-8b44c8bbfcab",
-    "heading": "The Star Wars story lives forever",
-    "subheading": "Watch Now On Disney+",
-    "link": "https://disneyplus.bn5x.net/333RX",
-    "links": {
-      "article": "https://disneyplus.bn5x.net/dANAy",
-      "search": "https://disneyplus.bn5x.net/mB93y"
-    },
-    "country": [
-      "AU",
-      "NZ"
-    ],
-    "isBig": true,
-    "launchOn": "2019-11-18T22:00:00Z"
-  },
-  {
-    "campaign": "disneyplus",
-    "category": "simpsons",
-    "tagline": "Related Posts",
-    "image": "https://static.wikia.nocookie.net/2d18111c-bc45-458f-9898-d2d4e3a50589",
-    "heading": "Don't have a cow man, relive the Simpsons",
-    "subheading": "Watch Now On Disney+",
-    "link": "https://disneyplus.bn5x.net/DrrRa",
-    "links": {
-      "article": "https://disneyplus.bn5x.net/qq5qq",
-      "search": "https://disneyplus.bn5x.net/NV1DP"
-    },
-    "country": [
-      "AU",
-      "NZ"
-    ],
-    "launchOn": "2019-11-18T22:00:00Z"
-  },
-  {
-    "campaign": "disneyplus",
-    "category": "simpsons",
-    "tagline": "Suggested For You",
-    "image": "https://static.wikia.nocookie.net/2d18111c-bc45-458f-9898-d2d4e3a50589",
-    "heading": "Don't have a cow man, relive the Simpsons",
-    "subheading": "Watch Now On Disney+",
-    "link": "https://disneyplus.bn5x.net/DrrRa",
-    "links": {
-      "article": "https://disneyplus.bn5x.net/23b9G",
-      "search": "https://disneyplus.bn5x.net/vrG3W"
-    },
-    "country": [
-      "AU",
-      "NZ"
-    ],
-    "isBig": true,
-    "launchOn": "2019-11-18T22:00:00Z"
   }
 ]

--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -7,6 +7,10 @@
     "heading": "This is a test affiliate unit",
     "subheading": "Click this link",
     "link": "https://www.fandom.com",
+    "links": {
+      "article": "https://www.fandom.com/article-3",
+      "search": "https://www.fandom.com/search-3"
+    },
     "country": ["US", "CA", "NL"]
   },
   {
@@ -17,6 +21,10 @@
     "heading": "This is a test affiliate unit",
     "subheading": "Click this link",
     "link": "https://www.fandom.com",
+    "links": {
+      "article": "https://www.fandom.com/article-1",
+      "search": "https://www.fandom.com/search-1"
+    },
     "country": ["US", "CA", "NL"],
     "isBig": true
   },
@@ -29,7 +37,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/DrrRa",
     "links": {
-      "page": "https://disneyplus.bn5x.net/qq5qq",
+      "article": "https://disneyplus.bn5x.net/qq5qq",
       "search": "https://disneyplus.bn5x.net/NV1DP"
     },
     "country": ["US", "CA", "NL"]
@@ -43,7 +51,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/DrrRa",
     "links": {
-      "page": "https://disneyplus.bn5x.net/23b9G",
+      "article": "https://disneyplus.bn5x.net/23b9G",
       "search": "https://disneyplus.bn5x.net/vrG3W"
     },
     "country": ["US", "CA", "NL"],
@@ -58,7 +66,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/333RX",
     "links": {
-      "page": "https://disneyplus.bn5x.net/PZJZM",
+      "article": "https://disneyplus.bn5x.net/PZJZM",
       "search": "https://disneyplus.bn5x.net/xPV33"
     },
     "country": ["US", "CA", "NL"]
@@ -72,7 +80,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/333RX",
     "links": {
-      "page": "https://disneyplus.bn5x.net/dANAy",
+      "article": "https://disneyplus.bn5x.net/dANAy",
       "search": "https://disneyplus.bn5x.net/mB93y"
     },
     "country": ["US", "CA", "NL"],
@@ -87,7 +95,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/YxZKm",
     "links": {
-      "page": "https://disneyplus.bn5x.net/9343Y",
+      "article": "https://disneyplus.bn5x.net/9343Y",
       "search": "https://disneyplus.bn5x.net/qq53q"
     },
     "country": ["US", "CA", "NL"]
@@ -101,7 +109,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/YxZKm",
     "links": {
-      "page": "https://disneyplus.bn5x.net/vrGrN",
+      "article": "https://disneyplus.bn5x.net/vrGrN",
       "search": "https://disneyplus.bn5x.net/77RrV"
     },
     "country": ["US", "CA", "NL"],
@@ -116,7 +124,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/NVVXv",
     "links": {
-      "page": "https://disneyplus.bn5x.net/Dr9rG",
+      "article": "https://disneyplus.bn5x.net/Dr9rG",
       "search": "https://disneyplus.bn5x.net/LGAq3"
     },
     "country": ["US", "CA", "NL"]
@@ -130,7 +138,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/NVVXv",
     "links": {
-      "page": "https://disneyplus.bn5x.net/RXgXy",
+      "article": "https://disneyplus.bn5x.net/RXgXy",
       "search": "https://disneyplus.bn5x.net/KAaLv"
     },
     "country": ["US", "CA", "NL"],
@@ -145,7 +153,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/333RX",
     "links": {
-      "page": "https://disneyplus.bn5x.net/PZJZM",
+      "article": "https://disneyplus.bn5x.net/PZJZM",
       "search": "https://disneyplus.bn5x.net/xPV33"
     },
     "country": ["US", "CA", "NL"]
@@ -159,7 +167,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/333RX",
     "links": {
-      "page": "https://disneyplus.bn5x.net/dANAy",
+      "article": "https://disneyplus.bn5x.net/dANAy",
       "search": "https://disneyplus.bn5x.net/mB93y"
     },
     "country": ["US", "CA", "NL"],
@@ -174,7 +182,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/DrrRa",
     "links": {
-      "page": "https://disneyplus.bn5x.net/qq5qq",
+      "article": "https://disneyplus.bn5x.net/qq5qq",
       "search": "https://disneyplus.bn5x.net/NV1DP"
     },
     "country": ["US", "CA", "NL"]
@@ -188,7 +196,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/DrrRa",
     "links": {
-      "page": "https://disneyplus.bn5x.net/23b9G",
+      "article": "https://disneyplus.bn5x.net/23b9G",
       "search": "https://disneyplus.bn5x.net/vrG3W"
     },
     "country": ["US", "CA", "NL"],
@@ -203,7 +211,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/DrrRa",
     "links": {
-      "page": "https://disneyplus.bn5x.net/qq5qq",
+      "article": "https://disneyplus.bn5x.net/qq5qq",
       "search": "https://disneyplus.bn5x.net/NV1DP"
     },
     "country": [
@@ -221,7 +229,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/DrrRa",
     "links": {
-      "page": "https://disneyplus.bn5x.net/23b9G",
+      "article": "https://disneyplus.bn5x.net/23b9G",
       "search": "https://disneyplus.bn5x.net/vrG3W"
     },
     "country": [
@@ -240,7 +248,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/333RX",
     "links": {
-      "page": "https://disneyplus.bn5x.net/PZJZM",
+      "article": "https://disneyplus.bn5x.net/PZJZM",
       "search": "https://disneyplus.bn5x.net/xPV33"
     },
     "country": [
@@ -258,7 +266,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/333RX",
     "links": {
-      "page": "https://disneyplus.bn5x.net/dANAy",
+      "article": "https://disneyplus.bn5x.net/dANAy",
       "search": "https://disneyplus.bn5x.net/mB93y"
     },
     "country": [
@@ -277,7 +285,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/YxZKm",
     "links": {
-      "page": "https://disneyplus.bn5x.net/9343Y",
+      "article": "https://disneyplus.bn5x.net/9343Y",
       "search": "https://disneyplus.bn5x.net/qq53q"
     },
     "country": [
@@ -295,7 +303,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/YxZKm",
     "links": {
-      "page": "https://disneyplus.bn5x.net/vrGrN",
+      "article": "https://disneyplus.bn5x.net/vrGrN",
       "search": "https://disneyplus.bn5x.net/77RrV"
     },
     "country": [
@@ -314,7 +322,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/NVVXv",
     "links": {
-      "page": "https://disneyplus.bn5x.net/Dr9rG",
+      "article": "https://disneyplus.bn5x.net/Dr9rG",
       "search": "https://disneyplus.bn5x.net/LGAq3"
     },
     "country": [
@@ -332,7 +340,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/NVVXv",
     "links": {
-      "page": "https://disneyplus.bn5x.net/RXgXy",
+      "article": "https://disneyplus.bn5x.net/RXgXy",
       "search": "https://disneyplus.bn5x.net/KAaLv"
     },
     "country": [
@@ -351,7 +359,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/333RX",
     "links": {
-      "page": "https://disneyplus.bn5x.net/PZJZM",
+      "article": "https://disneyplus.bn5x.net/PZJZM",
       "search": "https://disneyplus.bn5x.net/xPV33"
     },
     "country": [
@@ -369,7 +377,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/333RX",
     "links": {
-      "page": "https://disneyplus.bn5x.net/dANAy",
+      "article": "https://disneyplus.bn5x.net/dANAy",
       "search": "https://disneyplus.bn5x.net/mB93y"
     },
     "country": [
@@ -388,7 +396,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/DrrRa",
     "links": {
-      "page": "https://disneyplus.bn5x.net/qq5qq",
+      "article": "https://disneyplus.bn5x.net/qq5qq",
       "search": "https://disneyplus.bn5x.net/NV1DP"
     },
     "country": [
@@ -406,7 +414,7 @@
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/DrrRa",
     "links": {
-      "page": "https://disneyplus.bn5x.net/23b9G",
+      "article": "https://disneyplus.bn5x.net/23b9G",
       "search": "https://disneyplus.bn5x.net/vrG3W"
     },
     "country": [

--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -28,6 +28,10 @@
     "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/DrrRa",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/qq5qq",
+      "search": "https://disneyplus.bn5x.net/NV1DP"
+    },
     "country": ["US", "CA", "NL"]
   },
   {
@@ -38,6 +42,10 @@
     "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/DrrRa",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/23b9G",
+      "search": "https://disneyplus.bn5x.net/vrG3W"
+    },
     "country": ["US", "CA", "NL"],
     "isBig": true
   },
@@ -49,6 +57,10 @@
     "heading": "A thrilling new adventure on the galactic frontier",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/333RX",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/PZJZM",
+      "search": "https://disneyplus.bn5x.net/xPV33"
+    },
     "country": ["US", "CA", "NL"]
   },
   {
@@ -59,6 +71,10 @@
     "heading": "A thrilling new adventure on the galactic frontier",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/333RX",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/dANAy",
+      "search": "https://disneyplus.bn5x.net/mB93y"
+    },
     "country": ["US", "CA", "NL"],
     "isBig": true
   },
@@ -70,6 +86,10 @@
     "heading": "All Avengers, All the Time",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/YxZKm",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/9343Y",
+      "search": "https://disneyplus.bn5x.net/qq53q"
+    },
     "country": ["US", "CA", "NL"]
   },
   {
@@ -80,6 +100,10 @@
     "heading": "All Avengers, All the Time",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/YxZKm",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/vrGrN",
+      "search": "https://disneyplus.bn5x.net/77RrV"
+    },
     "country": ["US", "CA", "NL"],
     "isBig": true
   },
@@ -91,6 +115,10 @@
     "heading": "The Incredibles- a family who saves the world together sticks together",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/NVVXv",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/Dr9rG",
+      "search": "https://disneyplus.bn5x.net/LGAq3"
+    },
     "country": ["US", "CA", "NL"]
   },
   {
@@ -101,6 +129,10 @@
     "heading": "The Incredibles- a family who saves the world together sticks together",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/NVVXv",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/RXgXy",
+      "search": "https://disneyplus.bn5x.net/KAaLv"
+    },
     "country": ["US", "CA", "NL"],
     "isBig": true
   },
@@ -112,6 +144,10 @@
     "heading": "The Star Wars story lives forever",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/333RX",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/PZJZM",
+      "search": "https://disneyplus.bn5x.net/xPV33"
+    },
     "country": ["US", "CA", "NL"]
   },
   {
@@ -122,6 +158,10 @@
     "heading": "The Star Wars story lives forever",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/333RX",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/dANAy",
+      "search": "https://disneyplus.bn5x.net/mB93y"
+    },
     "country": ["US", "CA", "NL"],
     "isBig": true
   },
@@ -133,6 +173,10 @@
     "heading": "Don't have a cow man, relive the Simpsons",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/DrrRa",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/qq5qq",
+      "search": "https://disneyplus.bn5x.net/NV1DP"
+    },
     "country": ["US", "CA", "NL"]
   },
   {
@@ -143,6 +187,10 @@
     "heading": "Don't have a cow man, relive the Simpsons",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/DrrRa",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/23b9G",
+      "search": "https://disneyplus.bn5x.net/vrG3W"
+    },
     "country": ["US", "CA", "NL"],
     "isBig": true
   },
@@ -154,6 +202,10 @@
     "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/DrrRa",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/qq5qq",
+      "search": "https://disneyplus.bn5x.net/NV1DP"
+    },
     "country": [
       "AU",
       "NZ"
@@ -168,6 +220,10 @@
     "heading": "Moana, a heroine kids and adults alike will admire and cheer for",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/DrrRa",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/23b9G",
+      "search": "https://disneyplus.bn5x.net/vrG3W"
+    },
     "country": [
       "AU",
       "NZ"
@@ -183,6 +239,10 @@
     "heading": "A thrilling new adventure on the galactic frontier",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/333RX",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/PZJZM",
+      "search": "https://disneyplus.bn5x.net/xPV33"
+    },
     "country": [
       "AU",
       "NZ"
@@ -197,6 +257,10 @@
     "heading": "A thrilling new adventure on the galactic frontier",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/333RX",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/dANAy",
+      "search": "https://disneyplus.bn5x.net/mB93y"
+    },
     "country": [
       "AU",
       "NZ"
@@ -212,6 +276,10 @@
     "heading": "All Avengers, All the Time",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/YxZKm",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/9343Y",
+      "search": "https://disneyplus.bn5x.net/qq53q"
+    },
     "country": [
       "AU",
       "NZ"
@@ -226,6 +294,10 @@
     "heading": "All Avengers, All the Time",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/YxZKm",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/vrGrN",
+      "search": "https://disneyplus.bn5x.net/77RrV"
+    },
     "country": [
       "AU",
       "NZ"
@@ -241,6 +313,10 @@
     "heading": "The Incredibles- a family who saves the world together sticks together",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/NVVXv",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/Dr9rG",
+      "search": "https://disneyplus.bn5x.net/LGAq3"
+    },
     "country": [
       "AU",
       "NZ"
@@ -255,6 +331,10 @@
     "heading": "The Incredibles- a family who saves the world together sticks together",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/NVVXv",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/RXgXy",
+      "search": "https://disneyplus.bn5x.net/KAaLv"
+    },
     "country": [
       "AU",
       "NZ"
@@ -270,6 +350,10 @@
     "heading": "The Star Wars story lives forever",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/333RX",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/PZJZM",
+      "search": "https://disneyplus.bn5x.net/xPV33"
+    },
     "country": [
       "AU",
       "NZ"
@@ -284,6 +368,10 @@
     "heading": "The Star Wars story lives forever",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/333RX",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/dANAy",
+      "search": "https://disneyplus.bn5x.net/mB93y"
+    },
     "country": [
       "AU",
       "NZ"
@@ -299,6 +387,10 @@
     "heading": "Don't have a cow man, relive the Simpsons",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/DrrRa",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/qq5qq",
+      "search": "https://disneyplus.bn5x.net/NV1DP"
+    },
     "country": [
       "AU",
       "NZ"
@@ -313,6 +405,10 @@
     "heading": "Don't have a cow man, relive the Simpsons",
     "subheading": "Watch Now On Disney+",
     "link": "https://disneyplus.bn5x.net/DrrRa",
+    "links": {
+      "page": "https://disneyplus.bn5x.net/23b9G",
+      "search": "https://disneyplus.bn5x.net/vrG3W"
+    },
     "country": [
       "AU",
       "NZ"

--- a/app/templates/components/affiliate-unit.hbs
+++ b/app/templates/components/affiliate-unit.hbs
@@ -3,7 +3,7 @@
   {{heading}}
 </div>
 <a
-  href={{getUnitLink}}
+  href={{unit.link}}
   class="affiliate-unit__link"
   rel="noopener sponsored"
   onClick={{action "trackAffiliateClick"}}

--- a/app/templates/components/affiliate-unit.hbs
+++ b/app/templates/components/affiliate-unit.hbs
@@ -3,7 +3,7 @@
   {{heading}}
 </div>
 <a
-  href={{unit.link}}
+  href={{getUnitLink}}
   class="affiliate-unit__link"
   rel="noopener sponsored"
   onClick={{action "trackAffiliateClick"}}

--- a/app/templates/components/post-search-results-affiliate-item.hbs
+++ b/app/templates/components/post-search-results-affiliate-item.hbs
@@ -2,7 +2,7 @@
   <img class="post-search-results-affiliate-item__image" src={{affiliateUnit.image}} alt={{affiliateUnit.heading}}>
 {{/if}}
 <a
-  href={{{affiliateUnit.link}}}
+  href={{getUnitLink}}
   class="post-search-results-affiliate-item__title wds-leading-tight"
   rel="noopener sponsored"
   onclick={{action "trackClick" postIndex affiliateUnit}}

--- a/config/bundlesize.js
+++ b/config/bundlesize.js
@@ -5,7 +5,7 @@ const assetsFolder = 'mobile-wiki/assets';
 module.exports = {
   'mobile-wiki.js': {
     pattern: `${assetsFolder}/mobile-wiki-*.js`,
-    limit: '511KB',
+    limit: '514KB',
   },
   'vendor.js': {
     pattern: `${assetsFolder}/vendor-*.js`,


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/CAKE-5318
* [Updated Links](https://docs.google.com/spreadsheets/d/1vGuJEZ0ncVQSXTrABM3YYHg2P531sWZosgNsq-uMy5M/edit#gid=1139825318)

## Description
For tracking purposes, we want to use affiliate links by unit and page for
- In-content Big Unit
- In-content Small Unit
- Search Big Unit
- Search Small Unit

In the code
- Updated `affiliate-slots-units.json` with affiliate unit links by page and position
- Added logic to display appropriate affiliate unit link
- Removed duplicate units and added "AU" and "NZ" to existing ones

## Reviewers
@Wikia/cake 
