### PR TITLE
IW | reduce worker count per pod and increase number of pods to havethe same total number of processes

### DIFF
--- a/fastboot-server/app/server.js
+++ b/fastboot-server/app/server.js
@@ -13,6 +13,7 @@ const server = new FastBootAppServer({
   afterMiddleware: middlewares.after,
   distPath: config.distPath,
   gzip: true,
+  workerCount: 16,
 });
 
 server.start();

--- a/k8s/k8s-deployment-descriptor-template-prod.yaml
+++ b/k8s/k8s-deployment-descriptor-template-prod.yaml
@@ -11,7 +11,7 @@ metadata:
     version: "${version}"
     status: active
 spec:
-  replicas: 8
+  replicas: 16
   selector:
     matchLabels:
       app: mobile-wiki


### PR DESCRIPTION
## Description

Recently we can see that mobile-wiki containers are restarted. It may be due the fact that they operate at memory limit (see grafana dashboard). Lets reduce number of node-cluster workers and increase number of pods instead.

## Reviewers
@Wikia/iwing 