### PR TITLE
hotfix-ADEN-9657 Update ad-engine (v49.12.3) (#1947)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1839,8 +1839,8 @@
       }
     },
     "@wikia/ad-engine": {
-      "version": "git+https://github.com/Wikia/ad-engine.git#93e2e49d0f1a178e622931a1ac468dab480cbea9",
-      "from": "git+https://github.com/Wikia/ad-engine.git#v49.12.1",
+      "version": "git+https://github.com/Wikia/ad-engine.git#c6a62f0b1fcf147f6468061c7494dbf120370166",
+      "from": "git+https://github.com/Wikia/ad-engine.git#v49.12.3",
       "requires": {
         "@babel/runtime-corejs2": "7.3.1",
         "@wikia/dependency-injection": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": "6.* || 8.* || >= 10.*"
   },
   "dependencies": {
-    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v49.12.1",
+    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v49.12.3",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#e39faa8af7e280ca2bcf099c2adbe92d08e96fbc",
     "@wikia/search-tracking": "github:Wikia/search-tracking#2.0.0",
     "@wikia/tracking-opt-in": "2.0.6",


### PR DESCRIPTION
## Description

Hotfix was release on 11/26 by AdEng in order to fix UAP HiVi.
This PR merges changes into release branch.
