### PR TITLE
cake-5385 | Update DDB launch date

### DIFF
--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -219,7 +219,7 @@
     "image": "https://static.wikia.nocookie.net/0cebb500-f8c3-4f44-b4aa-f44e33fc2319",
     "heading": "The Official Digital Toolset for Dungeons & Dragons",
     "subheading": "Visit D&D Beyond",
-    "launchOn": "2019-12-12T19:00:00Z",
+    "launchOn": "2019-12-17T19:00:00Z",
     "link": "https://www.dndbeyond.com/intro"
   },
   {
@@ -229,7 +229,7 @@
     "image": "https://static.wikia.nocookie.net/0cebb500-f8c3-4f44-b4aa-f44e33fc2319",
     "heading": "The Official Digital Toolset for Dungeons & Dragons",
     "subheading": "Visit D&D Beyond",
-    "launchOn": "2019-12-12T19:00:00Z",
+    "launchOn": "2019-12-17T19:00:00Z",
     "link": "https://www.dndbeyond.com/intro",
     "isBig": true
   }


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/CAKE-5385

## Description

Launch of the DDB campaign has been updated to December 17, 2019 at 11am PST.

Update the code to reflect launch date.

## Reviewers
@Wikia/cake 
