### PR TITLE
CAKE-5427 | Adjust Spacing & Gradient Color on Affiliate Units

### DIFF
--- a/app/styles/component/_affiliate-unit.scss
+++ b/app/styles/component/_affiliate-unit.scss
@@ -90,7 +90,7 @@
   margin: 28px -.75rem -22px;
 
   &__slant {
-    background-image: linear-gradient(-5deg, rgba(255, 255, 255, 0) 5%, $wds-color-white 60%, rgba(255, 255, 255, 0) 60%);
+    background-image: linear-gradient(-5deg, rgba(255, 255, 255, 0) 5%, $infobox-background 60%, rgba(255, 255, 255, 0) 60%);
     height: 130px;
     margin-bottom: 12px;
   }

--- a/app/styles/component/_affiliate-unit.scss
+++ b/app/styles/component/_affiliate-unit.scss
@@ -87,7 +87,7 @@
 }
 
 .article-content .aff-big-unit {
-  margin: 28px -.75rem 48px;
+  margin: 28px -.75rem -22px;
 
   &__slant {
     background-image: linear-gradient(-5deg, rgba(255, 255, 255, 0) 5%, $wds-color-white 60%, rgba(255, 255, 255, 0) 60%);

--- a/app/styles/component/_post-search-results.scss
+++ b/app/styles/component/_post-search-results.scss
@@ -66,7 +66,7 @@
   padding-bottom: none;
 
   &__slant {
-    background-image: linear-gradient(-5deg, rgba(255, 255, 255, 0) 5%, $wds-color-white 60%, rgba(255, 255, 255, 0) 60%);
+    background-image: linear-gradient(-5deg, rgba(255, 255, 255, 0) 5%, $infobox-background 60%, rgba(255, 255, 255, 0) 60%);
     height: 130px;
     margin: 0 -12px;
   }

--- a/app/styles/theme/_dark.scss
+++ b/app/styles/theme/_dark.scss
@@ -106,6 +106,14 @@ body {
   h6[section] {
     color: $section-header-color;
   }
+
+  .aff-big-unit__slant {
+    background-image: linear-gradient(-5deg, rgba(255, 255, 255, 0) 5%, $background-color 60%, rgba(255, 255, 255, 0) 60%);
+  }
+
+  .post-search-results__slant {
+    background-image: linear-gradient(-5deg, rgba(255, 255, 255, 0) 5%, $background-color 60%, rgba(255, 255, 255, 0) 60%);
+  }
 }
 
 .recirculation-prefooter {


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/CAKE-5427
* zpl://screen?sid=5db233296a01342c331fe781&pid=5c34f8570b5f05bdc9806cb9

## Description

There was too much space between affiliate units and ads beneath. This PR reduces the distance by using negative margin without negatively impacting the slant gradient.

Also, a bug was noticed that when using dark mode in the mobile app, the gradient needed to have a black rather than white background to stay consistent with the portable infobox background color.

## Reviewers

@Wikia/cake 
@JoshuaRogan 
