### PR TITLE
fix-midlines | Use rgba values and color variable

### DIFF
--- a/app/styles/theme/_dark.scss
+++ b/app/styles/theme/_dark.scss
@@ -130,7 +130,7 @@ body {
 
 .aff-big-unit {
   &__header {
-    background-image: linear-gradient(to top, rgba(203, 219, 222, .2) 54%, #000000e0 54%, #ffe8e800 100%);
+    background-image: linear-gradient(to top, rgba(203, 219, 222, .2) 54%, $background-color 54%, rgba(255, 255, 255, 0) 100%);
     color: $section-header-color;
   }
 
@@ -154,5 +154,5 @@ body {
 }
 
 .post-search-results__header-text {
-  background-image: linear-gradient(to top, rgba(203, 219, 222, .2) 54%, #000000e0 54%, #ffe8e800 100%);
+  background-image: linear-gradient(to top, rgba(203, 219, 222, .2) 54%, $background-color 54%, rgba(255, 255, 255, 0) 100%);
 }


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/CAKE-5395

## Description

Switched linear gradient colors back to **rgba** values. The errors might have only been on desktop and not actual android mobile device but because we can't test in live environment, this approach seems cleaner and worked when manually input into verify devtools console.

## Reviewers
@Wikia/cake 
@JoshuaRogan 
