### PR TITLE
IW-3076 | update ember-fandom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3017,8 +3017,8 @@
       }
     },
     "@wikia/ember-fandom": {
-      "version": "github:Wikia/ember-fandom#483cc2a6e39d2df9c6d5b82b06929efd9945e9b4",
-      "from": "github:Wikia/ember-fandom#483cc2a6e39d2df9c6d5b82b06929efd9945e9b4",
+      "version": "github:Wikia/ember-fandom#cadd49d019a6e8108b024df9155b4ab17bb24006",
+      "from": "github:Wikia/ember-fandom#cadd49d019a6e8108b024df9155b4ab17bb24006",
       "requires": {
         "ember-auto-import": "1.2.19",
         "ember-cli-babel": "6.14.1",
@@ -6460,7 +6460,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         }
@@ -7956,7 +7956,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -26079,9 +26079,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.41.5",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.5.tgz",
-      "integrity": "sha512-wp0Co4vpyumnp3KlkmpM5LWuzvZYayDwM2n17EHFr4qxBBbRokC7DJawPJC7TfSFZ9HZ6GsdH40EBj4UV0nmpw==",
+      "version": "4.41.6",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.6.tgz",
+      "integrity": "sha512-yxXfV0Zv9WMGRD+QexkZzmGIh54bsvEs+9aRWxnN8erLWEOehAKUTeNBoUbA6HPEZPlRo7KDi2ZcNveoZgK9MA==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-module-context": "1.8.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v57.0.1",
-    "@wikia/ember-fandom": "github:Wikia/ember-fandom#483cc2a6e39d2df9c6d5b82b06929efd9945e9b4",
+    "@wikia/ember-fandom": "github:Wikia/ember-fandom#cadd49d019a6e8108b024df9155b4ab17bb24006",
     "@wikia/post-quecast": "1.2.0",
     "@wikia/search-tracking": "github:Wikia/search-tracking#2.0.0",
     "@wikia/tracking-opt-in": "3.0.1",


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/IW-3076
* https://github.com/Wikia/ember-fandom/pull/41

## Description
temporary hack meant for allowing testing ucp wikis on prod broke all wikis starting with ucp-internal-test prefix on devboxes

## Reviewers

@Wikia/iwing 
