### PR TITLE
fix border-radius for hero image

### DIFF
--- a/app/styles/component/wikia-ui-components/_wiki-page-header.scss
+++ b/app/styles/component/wikia-ui-components/_wiki-page-header.scss
@@ -12,9 +12,7 @@
 
     img {
       border: none;
-      border-radius: unset;
-      border-top-left-radius: 4px;
-      border-top-right-radius: 4px;
+      border-radius: 4px 4px 0 0;
       box-shadow: 0 6px 10px 0 rgba($wds-color-black, .1);
       height: calc((100vw - 2 * #{$article-horizontal-padding}) * 5 / 4);
       width: calc(100vw - 2 * #{$article-horizontal-padding});


### PR DESCRIPTION
## Description
such rules:
```
border-radius: unset;
border-top-left-radius: 4px;	
border-top-right-radius: 4px;
```
were compiled into single `border-radius: 4px 4px unset unset;` rule which made chrome to complain about `unset` not being a valid value for `border-radius`.

## Reviewers

@Wikia/iwing 
