### PR TITLE
(PLATFORM-4370) Update ember-fandom version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3257,8 +3257,8 @@
       }
     },
     "@wikia/ember-fandom": {
-      "version": "github:Wikia/ember-fandom#cadd49d019a6e8108b024df9155b4ab17bb24006",
-      "from": "github:Wikia/ember-fandom#cadd49d019a6e8108b024df9155b4ab17bb24006",
+      "version": "github:Wikia/ember-fandom#a436b8294fabd149152b7c446ebef1f804c08beb",
+      "from": "github:Wikia/ember-fandom#a436b8294fabd149152b7c446ebef1f804c08beb",
       "requires": {
         "ember-auto-import": "1.2.19",
         "ember-cli-babel": "6.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3257,8 +3257,8 @@
       }
     },
     "@wikia/ember-fandom": {
-      "version": "github:Wikia/ember-fandom#a436b8294fabd149152b7c446ebef1f804c08beb",
-      "from": "github:Wikia/ember-fandom#a436b8294fabd149152b7c446ebef1f804c08beb",
+      "version": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",
+      "from": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",
       "requires": {
         "ember-auto-import": "1.2.19",
         "ember-cli-babel": "6.14.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v58.8.0",
-    "@wikia/ember-fandom": "github:Wikia/ember-fandom#cadd49d019a6e8108b024df9155b4ab17bb24006",
+    "@wikia/ember-fandom": "github:Wikia/ember-fandom#a436b8294fabd149152b7c446ebef1f804c08beb",
     "@wikia/post-quecast": "1.2.0",
     "@wikia/search-tracking": "github:Wikia/search-tracking#2.0.0",
     "@wikia/tracking-opt-in": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v58.8.0",
-    "@wikia/ember-fandom": "github:Wikia/ember-fandom#a436b8294fabd149152b7c446ebef1f804c08beb",
+    "@wikia/ember-fandom": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",
     "@wikia/post-quecast": "1.2.0",
     "@wikia/search-tracking": "github:Wikia/search-tracking#2.0.0",
     "@wikia/tracking-opt-in": "3.0.2",


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/PLATFORM-4370

## Description

Update ember-fandom version for externaltest and showcase HTTPS support changes.

## Reviewers

@Wikia/core-platform-team 
