### PR TITLE
CAKE-5623 | Add Disney+ French unit

### DIFF
--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -270,6 +270,7 @@
     "subheading": "Jours d’Essai Gratuits",
     "link": "https://disneyplus.bn5x.net/c/1947570/772639/9358?subId1=generic-fr&subId2=launch&subId3=ad-fandom&sharedid=mobile",
     "country": ["FR"],
+    "launchOn": "2020-04-07T06:00:00Z",
     "isBig": true
   },
   {

--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -268,7 +268,7 @@
     "image": "https://static.wikia.nocookie.net/2d649352-f023-4b87-91a3-a8ee13f74b45/",
     "heading": "Regardez tous vos Disney favoris, au même endroit.",
     "subheading": "Jours d’Essai Gratuits",
-    "link": "https://disneyplus.bn5x.net/c/1947570/772705/9358?subId1=generic-es&subId2=launch&subId3=ad-fandom&sharedid=mobile",
+    "link": "https://disneyplus.bn5x.net/c/1947570/772639/9358?subId1=generic-fr&subId2=launch&subId3=ad-fandom&sharedid=mobile",
     "country": ["FR"],
     "isBig": true
   },

--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -264,6 +264,17 @@
   {
     "campaign": "disneyplus",
     "category": "disney",
+    "tagline": "Abonnez-vous Maintenant",
+    "image": "https://static.wikia.nocookie.net/2d649352-f023-4b87-91a3-a8ee13f74b45/",
+    "heading": "Regardez tous vos Disney favoris, au même endroit.",
+    "subheading": "Jours d’Essai Gratuits",
+    "link": "https://disneyplus.bn5x.net/c/1947570/772705/9358?subId1=generic-es&subId2=launch&subId3=ad-fandom&sharedid=mobile",
+    "country": ["FR"],
+    "isBig": true
+  },
+  {
+    "campaign": "disneyplus",
+    "category": "disney",
     "tagline": "Suggested For You",
     "image": "https://static.wikia.nocookie.net/2d649352-f023-4b87-91a3-a8ee13f74b45/",
     "heading": "Watch Your Disney Favorites, All In One Place.",


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/CAKE-5623
* [Disney+ Affiliate Links List](https://disneyplus.bn5x.net/c/1947570/772639/9358?subId1=generic-fr&subId2=launch&subId3=ad-fandom&sharedid=mobile)

## Description

Add French Unit to be launched on April 7, 2020 at 7am BST.

## Reviewers

@Wikia/cake 
@unijuglr 
