### PR TITLE
cake-5629 | Use proper translation file for header

### DIFF
--- a/app/components/post-search-results.js
+++ b/app/components/post-search-results.js
@@ -70,7 +70,7 @@ export default Component.extend(
       if (this.unit && this.unit.tagline) {
         return this.unit.tagline;
       }
-      return this.i18n.t('main.search-post-items-header');
+      return this.i18n.t('main.search-post-items-header', { ns: 'search' });
     }),
 
     didInsertElement() {

--- a/config/bundlesize.js
+++ b/config/bundlesize.js
@@ -5,7 +5,7 @@ const assetsFolder = 'mobile-wiki/assets';
 module.exports = {
   'mobile-wiki.js': {
     pattern: `${assetsFolder}/mobile-wiki-*.js`,
-    limit: '522KB',
+    limit: '523KB',
   },
   'vendor.js': {
     pattern: `${assetsFolder}/vendor-*.js`,


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/CAKE-5629

## Description

So far, all of our affiliate units have included a tagline, but when one isn't provided, a default value is pulled from `search.json` for the various locales. The **ns** parameter was left off the original PR and was looking for the string in `main.json` rather than `search.json`.

* This PR also exceeded mobile-wiki's bundle size of 522Kb. I have increased the limit by one until a better limit can be determined.

## Reviewers

@Wikia/cake 
@unijuglr 
