### PR TITLE
ADEN-10188 Update ad-engine (v61.0.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3231,8 +3231,8 @@
       }
     },
     "@wikia/ad-engine": {
-      "version": "git+https://github.com/Wikia/ad-engine.git#f00f495ac957fef74175d0d09ab951c7f4c8467d",
-      "from": "git+https://github.com/Wikia/ad-engine.git#v61.0.4",
+      "version": "git+https://github.com/Wikia/ad-engine.git#6a20e1409ebe8a12115980686dd4d5ac64da48cb",
+      "from": "git+https://github.com/Wikia/ad-engine.git#v61.0.5",
       "requires": {
         "@babel/runtime-corejs2": "^7.3.1",
         "@wikia/dependency-injection": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": ">= 10.*"
   },
   "dependencies": {
-    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v61.0.4",
+    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v61.0.5",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",
     "@wikia/post-quecast": "1.2.0",
     "@wikia/search-tracking": "github:Wikia/search-tracking#2.0.0",


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/ADEN-10188
* https://github.com/Wikia/ad-engine/pull/761
* https://github.com/Wikia/ad-tests/pull/195

## Description
A workaround for redirect issues.
