### PR TITLE
Cake 5678 - Create new Campaign for HBO Max in Mobile and Desktop in-content Affiliate units

### DIFF
--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -7,7 +7,7 @@
     "subheading": "START YOUR FREE TRAIL",
     "link": "https://www.hbomax.com/gzm",
     "image": "https://static.wikia.nocookie.net/2ef28d1f-a27b-4ba3-943e-33948fddd089",
-    "extra_disclaimer": "Free trail for new customers only. Retrictions Apply."
+    "extra_disclaimer": "Free trail for new customers only. Restrictions Apply."
   },
   {
     "campaign": "ddb",

--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -4,20 +4,10 @@
     "category": "hbomax",
     "country": ["US"],
     "heading": "Where HBO Meets So Much More",
-    "subheading": "START YOUR FREE TRAIL",
+    "subheading": "START YOUR FREE TRIAL",
     "link": "https://www.hbomax.com/gzm",
     "image": "https://static.wikia.nocookie.net/2ef28d1f-a27b-4ba3-943e-33948fddd089",
-    "extra_disclaimer": "Free trail for new customers only. Restrictions Apply."
-  },
-  {
-    "campaign": "ddb",
-    "category": "ddb-test-unit-id",
-    "tagline": "Suggested For You",
-    "image": "https://static.wikia.nocookie.net/2d18111c-bc45-458f-9898-d2d4e3a50589",
-    "heading": "CLICK ME FOR DDB",
-    "subheading": "DDB subheading",
-    "link": "https://www.dndbeyond.com/",
-    "country": ["US", "CA", "NL"]
+    "extraDisclaimer": "Free trial for new customers only. Restrictions Apply."
   },
   {
     "campaign": "ddb",

--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -7,7 +7,8 @@
     "subheading": "START YOUR FREE TRIAL",
     "link": "https://www.hbomax.com/gzm",
     "image": "https://static.wikia.nocookie.net/2ef28d1f-a27b-4ba3-943e-33948fddd089",
-    "extraDisclaimer": "Free trial for new customers only. Restrictions Apply."
+    "extraDisclaimer": "Free trial for new customers only. Restrictions Apply.",
+    "isBig": true
   },
   {
     "campaign": "ddb",

--- a/app/services/affiliate-slots-units.json
+++ b/app/services/affiliate-slots-units.json
@@ -1,5 +1,25 @@
 [
   {
+    "campaign": "hbomax",
+    "category": "hbomax",
+    "country": ["US"],
+    "heading": "Where HBO Meets So Much More",
+    "subheading": "START YOUR FREE TRAIL",
+    "link": "https://www.hbomax.com/gzm",
+    "image": "https://static.wikia.nocookie.net/2ef28d1f-a27b-4ba3-943e-33948fddd089",
+    "extra_disclaimer": "Free trail for new customers only. Retrictions Apply."
+  },
+  {
+    "campaign": "ddb",
+    "category": "ddb-test-unit-id",
+    "tagline": "Suggested For You",
+    "image": "https://static.wikia.nocookie.net/2d18111c-bc45-458f-9898-d2d4e3a50589",
+    "heading": "CLICK ME FOR DDB",
+    "subheading": "DDB subheading",
+    "link": "https://www.dndbeyond.com/",
+    "country": ["US", "CA", "NL"]
+  },
+  {
     "campaign": "ddb",
     "category": "ddb-test-unit-id",
     "tagline": "Suggested For You",

--- a/app/templates/components/affiliate-unit.hbs
+++ b/app/templates/components/affiliate-unit.hbs
@@ -23,7 +23,7 @@
   {{/if}}
 </a>
 <div class="aff-big-unit__disclaimer">
-  {{i18n "affiliate-unit.disclaimer"}} {{unit.extra_disclaimer}}
+  {{i18n "affiliate-unit.disclaimer"}} {{unit.extraDisclaimer}}
 </div>
 <div class="aff-big-unit__diagonal">
   <div class="aff-big-unit__diagonal__slant"></div>

--- a/app/templates/components/affiliate-unit.hbs
+++ b/app/templates/components/affiliate-unit.hbs
@@ -23,7 +23,7 @@
   {{/if}}
 </a>
 <div class="aff-big-unit__disclaimer">
-  {{i18n "affiliate-unit.disclaimer"}}
+  {{i18n "affiliate-unit.disclaimer"}} {{unit.extra_disclaimer}}
 </div>
 <div class="aff-big-unit__diagonal">
   <div class="aff-big-unit__diagonal__slant"></div>


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/CAKE-5678

## Description
Adding config and a slight template addition to support HBO MAX campaign
Can go live without concern, because it will be controlled by db rows being added at launch time

## Reviewers

Use `@` mentions here. Alternatively, assign the pull request to a person.
@Wikia/cake 
