### PR TITLE
Increase bundle size by one

### DIFF
--- a/config/bundlesize.js
+++ b/config/bundlesize.js
@@ -5,7 +5,7 @@ const assetsFolder = 'mobile-wiki/assets';
 module.exports = {
   'mobile-wiki.js': {
     pattern: `${assetsFolder}/mobile-wiki-*.js`,
-    limit: '526KB',
+    limit: '527KB',
   },
   'vendor.js': {
     pattern: `${assetsFolder}/vendor-*.js`,


### PR DESCRIPTION
## Links
[Jenkins Build Error](http://prod.jenkins.service.sjc.consul:8080/blue/organizations/jenkins/mobile-wiki-pr-checks-2/detail/dev/821/pipeline)

## Description

The latest commit pushed the bundlesize over the limit and caused Jenkins PR checks to fail. I've increased the bundle size limit by 1kb.

## Reviewers

@Wikia/cake 
@unijuglr 
