### PR TITLE
ADEN-10297 BFAB video size in impact state fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3234,8 +3234,8 @@
       }
     },
     "@wikia/ad-engine": {
-      "version": "git+https://github.com/Wikia/ad-engine.git#4c7c65128e24693d0fe97e270c13754fbc57572f",
-      "from": "git+https://github.com/Wikia/ad-engine.git#v65.1.1",
+      "version": "git+https://github.com/Wikia/ad-engine.git#d59728a8ec000c487710c5263a8a06e2c6fe8a4c",
+      "from": "git+https://github.com/Wikia/ad-engine.git#v65.1.2",
       "requires": {
         "@babel/runtime-corejs2": "^7.3.1",
         "@wikia/dependency-injection": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": ">= 10.*"
   },
   "dependencies": {
-    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v65.1.1",
+    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v65.1.2",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",
     "@wikia/post-quecast": "1.2.0",
     "@wikia/search-tracking": "github:Wikia/search-tracking#2.0.0",


### PR DESCRIPTION
ADEN-10297 Update ad-engine (v65.1.2) - fix BFAB video size in impact state

## Links
* https://wikia-inc.atlassian.net/browse/ADEN-10297