### PR TITLE
Short cache TTL for JWPlayer.js

### DIFF
--- a/fastboot-server/static-assets.js
+++ b/fastboot-server/static-assets.js
@@ -1,10 +1,16 @@
 const express = require('express');
 const config = require('../config/fastboot-server');
 
+const shortTTLAssets = ['webEditor/JWPlayer.js'];
+
+const isShortTTLAsset = path => shortTTLAssets.some(asset => path.endsWith(asset));
+
 module.exports = express.static(config.distPath, {
-  setHeaders: (res) => {
-    res.set('Cache-Control', `s-maxage=${config.staticAssetsTTL}`);
-    res.set('X-Pass-Cache-Control', `public, max-age=${config.staticAssetsTTL}`);
+  setHeaders: (res, path) => {
+    const ttl = isShortTTLAsset(path) ? 5 * 60 : config.staticAssetsTTL;
+
+    res.set('Cache-Control', `s-maxage=${ttl}`);
+    res.set('X-Pass-Cache-Control', `public, max-age=${ttl}`);
     res.set('Vary', 'accept-encoding');
   },
 });


### PR DESCRIPTION
There is no fingerprint added to dynamic imported chunks from AC so I set cache TTL to 5 min for this asset