### PR TITLE
IW-3551 | Load article comments by title and namespace

### DIFF
--- a/app/components/article-comments.js
+++ b/app/components/article-comments.js
@@ -22,6 +22,8 @@ export default Component.extend(InViewportMixin, {
 
   page: null,
   articleId: null,
+  articleTitle: null,
+  articleNamespace: null,
   commentsCount: null,
   model: null,
   isUcp: false,
@@ -164,7 +166,7 @@ export default Component.extend(InViewportMixin, {
 
   fetchCommentsBasedOnPlatform() {
     if (this.isUcp) {
-      this.articleComments.load({ title: this.articleTitle, id: this.articleId });
+      this.articleComments.load({ title: this.articleTitle, namespace: this.articleNamespace });
     } else {
       this.fetchComments(parseInt(this.page, 10));
     }

--- a/app/services/article-comments.js
+++ b/app/services/article-comments.js
@@ -33,22 +33,23 @@ export default Service.extend({
       });
   },
 
-  fetchCount(id) {
+  fetchCount(title, namespace) {
     const url = this.wikiUrls.build({
       host: this.get('wikiVariables.host'),
       path: '/wikia.php',
       query: {
         controller: 'Fandom\\ArticleComments\\Api\\ArticleCommentsController',
         method: 'getCommentCount',
-        articleId: id,
         hideDeleted: true,
+        title,
+        namespace,
       },
     });
 
     return this.fetch.fetchFromMediawiki(url, ArticleCommentsFetchError);
   },
 
-  load({ title, id }) {
+  load({ title, namespace }) {
     window.fandomWebEditorPublicPath = '/mobile-wiki/assets/webEditor/';
 
     Promise.all([
@@ -74,7 +75,7 @@ export default Service.extend({
 
       const env = {
         articleTitle: title,
-        articleId: id,
+        articleNamespace: namespace,
         apiBaseUrl: this.wikiUrls.build({
           host: this.wikiVariables.host,
           path: '/wikia.php',

--- a/app/templates/components/article-wrapper.hbs
+++ b/app/templates/components/article-wrapper.hbs
@@ -57,6 +57,7 @@
       articleId=model.id
       isUcp=model.isUcp
       articleTitle=model.title
+      articleNamespace=model.ns
       commentsCount=model.comments
       page=commentsPage
       class="article-footer-item"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2597,9 +2597,9 @@
       }
     },
     "@fandom/article-comments": {
-      "version": "0.3.0",
-      "resolved": "https://artifactory.wikia-inc.com:443/artifactory/api/npm/wikia-npm/@fandom/article-comments/-/@fandom/article-comments-0.3.0.tgz",
-      "integrity": "sha1-yo9OjWbMDeyE5Z2iVnyuDt10XSs="
+      "version": "0.4.0-comments",
+      "resolved": "https://artifactory.wikia-inc.com:443/artifactory/api/npm/wikia-npm/@fandom/article-comments/-/@fandom/article-comments-0.4.0-comments.tgz",
+      "integrity": "sha1-wVP+C6tpMvO536A1a6AuSgdwPho="
     },
     "@fandom/web-editor": {
       "version": "1.2.3",
@@ -7466,7 +7466,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -11746,7 +11746,7 @@
         },
         "ember-cli-babel": {
           "version": "6.12.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.12.0.tgz",
+          "resolved": "http://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.12.0.tgz",
           "integrity": "sha512-LMwZ3Xf3Q3jQUXaJtLLJsbbhRZRNv/iea64lZ8OgqZp1fh66CSXfmqV3L9QSuYQKPDNqFiu2v6IpOT08C6GU6w==",
           "requires": {
             "amd-name-resolver": "0.0.7",
@@ -26134,7 +26134,7 @@
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": ">= 10.*"
   },
   "dependencies": {
-    "@fandom/article-comments": "0.3.0",
+    "@fandom/article-comments": "0.4.0-comments",
     "@fandom/web-editor": "1.2.3",
     "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v66.0.0",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",

--- a/tests/integration/components/article-comments-test.js
+++ b/tests/integration/components/article-comments-test.js
@@ -1,0 +1,80 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+import Service from '@ember/service';
+
+module('Integration | Component | article-comments', (hooks) => {
+  setupRenderingTest(hooks);
+
+  let load;
+  let fetchCount;
+
+  hooks.beforeEach(function () {
+    load = sinon.spy();
+    fetchCount = sinon.stub();
+    this.owner.register('service:article-comments', Service.extend({ load, fetchCount }));
+    this.owner.register('service:i18n', Service.extend({ t: key => key }));
+    this.owner.register('service:wikiVariables', Service.extend({
+      // To match mirage fixture for comments API
+      host: 'fallout.wikia.com',
+    }));
+  });
+
+  test('calls load and renders empty container for UCP', async function (assert) {
+    assert.expect(2);
+
+    this.setProperties({
+      // To match mirage fixture for comments API
+      articleId: 10,
+      articleTitle: 'Foo',
+      articleNamespace: 0,
+      isUcp: true,
+    });
+
+    fetchCount.withArgs(this.get('articleId')).returns(Promise.resolve(8));
+
+    await render(hbs`<ArticleComments @isUcp={{this.isUcp}} @page="1" @articleId={{this.articleId}} @articleTitle={{this.articleTitle}} @articleNamespace={{this.articleNamespace}} />`);
+
+    assert.dom('#articleComments').exists();
+    assert.ok(load.calledOnceWith({
+      title: this.get('articleTitle'),
+      namespace: this.get('articleNamespace'),
+    }));
+  });
+
+  test('hides comment section for UCP when toggle is clicked', async function (assert) {
+    assert.expect(2);
+
+    this.setProperties({
+      articleId: 10,
+      articleTitle: 'Foo',
+      articleNamespace: 0,
+      isUcp: true,
+    });
+
+    await render(hbs`<ArticleComments @isUcp={{this.isUcp}} @page="1" @articleId={{this.articleId}} @articleTitle={{this.articleTitle}} @articleNamespace={{this.articleNamespace}} />`);
+    await click('.show-comments-btn');
+
+    assert.dom('#articleComments').doesNotExist();
+    assert.dom('.show-comments-btn').hasClass('collapsed');
+  });
+
+  test('renders comments from BE on non-UCP', async function (assert) {
+    assert.expect(2);
+
+    this.setProperties({
+      articleId: 10,
+      articleTitle: 'Foo',
+      articleNamespace: 0,
+      isUcp: false,
+      commentsCount: 7,
+    });
+
+    await render(hbs`<ArticleComments @isUcp={{this.isUcp}} @page="1" @commentsCount={{this.commentsCount}} @articleId={{this.articleId}} @articleTitle={{this.articleTitle}} @articleNamespace={{this.articleNamespace}} />`);
+
+    assert.dom('#articleComments').doesNotExist();
+    assert.dom('ul.comments > *').exists({ count: this.get('commentsCount') });
+  });
+});


### PR DESCRIPTION
## Links
* http://wikia-inc.atlassian.net/browse/IW-3551

## Description
As per https://github.com/Wikia/unified-platform/pull/2290, update mobile-wiki
to fetch comments by title and namespace, rather than article ID.
