### PR TITLE
MAIN-21046 | fix location header value for redirects

### DIFF
--- a/app/routes/wiki-page.js
+++ b/app/routes/wiki-page.js
@@ -147,12 +147,12 @@ export default Route.extend(
         }
 
         if (model.redirected) {
-          const encodedTitle = encodeURIComponent(normalizeToUnderscore(model.title));
-
           if (fastboot.get('isFastBoot')) {
-            fastboot.get('response.headers').set('location', encodedTitle);
+            fastboot.get('response.headers').set('location', model.url);
             fastboot.set('response.statusCode', 301);
           } else {
+            const encodedTitle = encodeURIComponent(normalizeToUnderscore(model.title));
+
             this.transitionTo('wiki-page', encodedTitle);
           }
 


### PR DESCRIPTION
## Links
* http://wikia-inc.atlassian.net/browse/MAIN-21046

## Description
Before this change, location header contained article title without namespace prefix, therefore redirect could not worki for cases provided in the ticket.

## Reviewers
@Wikia/iwing 
@Grunny 
