### PR TITLE
Moving the scroll speed to only track to the DW, per nAndy

### DIFF
--- a/app/utils/track.js
+++ b/app/utils/track.js
@@ -221,7 +221,7 @@ export function trackScrollY(time, scrollY) {
     action: 'scroll',
     category: 'scroll_speed',
     label: `${time}s|${scrollY}`,
-    trackingMethod: TrackingMethod.internal
+    trackingMethod: TrackingMethod.internal,
   });
 }
 

--- a/app/utils/track.js
+++ b/app/utils/track.js
@@ -145,7 +145,7 @@ export function track(params, usePrefix = true, force = false) {
   const isNonInteractive = params.isNonInteractive !== false;
   const pvUID = window.pvUID;
   const {
-    action, label = '', value = 0, trackingMethod = TrackingMethod.both,
+    action, label = '', value = 0, trackingMethod = TrackingMethod.internal,
   } = params;
 
   params = Object.assign({

--- a/app/utils/track.js
+++ b/app/utils/track.js
@@ -145,7 +145,7 @@ export function track(params, usePrefix = true, force = false) {
   const isNonInteractive = params.isNonInteractive !== false;
   const pvUID = window.pvUID;
   const {
-    action, label = '', value = 0, trackingMethod = TrackingMethod.internal,
+    action, label = '', value = 0, trackingMethod = TrackingMethod.both,
   } = params;
 
   params = Object.assign({

--- a/app/utils/track.js
+++ b/app/utils/track.js
@@ -221,6 +221,7 @@ export function trackScrollY(time, scrollY) {
     action: 'scroll',
     category: 'scroll_speed',
     label: `${time}s|${scrollY}`,
+    trackingMethod: TrackingMethod.internal
   });
 }
 


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/JIRA-123
* more relevant links

## Description
Just changing the parameter for where this routes, so that we can cut it off from flooding GA. This was turned off at the GTM level for 2 weeks previously, with no impact noticed. It only went back on because we had to pull jQuery out of the mix, and that code in GTM was reliant on it. 

Going forward, planning on updating code in the codebase to effect such changes, rather than override in GTM. This is just the first example. 

## Reviewers

Use `@` mentions here. Alternatively, assign the pull request to a person.
