### PR TITLE
ADEN-10469 Update ad-engine (second call slots with src=uap when SafeFanTakeover is loaded)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3244,8 +3244,8 @@
       }
     },
     "@wikia/ad-engine": {
-      "version": "git+https://github.com/Wikia/ad-engine.git#29d148823d7bd0cc60d702067aaaac7fa5e34971",
-      "from": "git+https://github.com/Wikia/ad-engine.git#29d148823d7bd0cc60d702067aaaac7fa5e34971",
+      "version": "git+https://github.com/Wikia/ad-engine.git#bfa99e4af54d2aec874fcb042d1f608474a37abb",
+      "from": "git+https://github.com/Wikia/ad-engine.git#v71.4.0",
       "requires": {
         "@babel/runtime-corejs2": "^7.3.1",
         "@wikia/dependency-injection": "2.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3244,8 +3244,8 @@
       }
     },
     "@wikia/ad-engine": {
-      "version": "git+https://github.com/Wikia/ad-engine.git#aa3eae45f24d2ed6ff1463bcc34fc4c2880c8aa1",
-      "from": "git+https://github.com/Wikia/ad-engine.git#v71.3.5",
+      "version": "git+https://github.com/Wikia/ad-engine.git#29d148823d7bd0cc60d702067aaaac7fa5e34971",
+      "from": "git+https://github.com/Wikia/ad-engine.git#29d148823d7bd0cc60d702067aaaac7fa5e34971",
       "requires": {
         "@babel/runtime-corejs2": "^7.3.1",
         "@wikia/dependency-injection": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fandom/article-comments": "0.9.3",
     "@fandom/web-editor": "1.4.1",
-    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v71.3.5",
+    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#29d148823d7bd0cc60d702067aaaac7fa5e34971",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",
     "@wikia/post-quecast": "2.0.1",
     "@wikia/search-tracking": "github:Wikia/search-tracking#2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fandom/article-comments": "0.9.3",
     "@fandom/web-editor": "1.4.1",
-    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#29d148823d7bd0cc60d702067aaaac7fa5e34971",
+    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v71.4.0",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",
     "@wikia/post-quecast": "2.0.1",
     "@wikia/search-tracking": "github:Wikia/search-tracking#2.0.0",


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/ADEN-10469