### PR TITLE
ADEN-10506 | Reverting tracking-opt-in version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",
     "@wikia/post-quecast": "2.0.1",
     "@wikia/search-tracking": "github:Wikia/search-tracking#2.0.0",
-    "@wikia/tracking-opt-in": "4.0.1",
+    "@wikia/tracking-opt-in": "3.0.6",
     "body-parser": "1.19.0",
     "bunyan-prettystream": "0.1.3",
     "compression": "1.7.4",


### PR DESCRIPTION
This seems to be causing all the subsequent pageviews above the first one not to be tracked in GA.

Let's revert, hotfix on prod and then figure out what's the issue on the tracking-opt-in side.