### PR TITLE
IW | generate proper mediawiki service name for verify env

### DIFF
--- a/tasks/k8s-descriptor.sh
+++ b/tasks/k8s-descriptor.sh
@@ -17,7 +17,7 @@ if expr "${ENV}" : "prod" 1>/dev/null; then
     SERVICE_TEMPLATE_NAME="k8s-service-descriptor-template-prod.yaml"
 fi
 
-if expr "${ENV}" : "preview" 1>/dev/null; then
+if [[ "${ENV}" == "preview" ]] || [[ "${ENV}" == "verify" ]]; then
     UCP_SUFFIX="-ucp"
 fi
 


### PR DESCRIPTION
Currently mobile-wiki-verify tries to talk to mediawiki-verify instead of mediawiki-verify-ucp. Lets fix it!

**QA notes**:
deploy to sandbox and to verify and check if it works

## Reviewers

@Wikia/iwing 
