### PR TITLE
IW-4118 | fix scroll on article comments page

### DIFF
--- a/app/components/article-comments.js
+++ b/app/components/article-comments.js
@@ -68,7 +68,7 @@ export default Component.extend(InViewportMixin, {
 
     this._super(...arguments);
 
-    if (page !== null) {
+    if (page !== null && page !== undefined) {
       this.set('isCollapsed', false);
       this.fetchCommentsBasedOnPlatform(this.page);
 

--- a/tests/integration/components/article-comments-test.js
+++ b/tests/integration/components/article-comments-test.js
@@ -77,4 +77,49 @@ module('Integration | Component | article-comments', (hooks) => {
     assert.dom('#articleComments').doesNotExist();
     assert.dom('ul.comments > *').exists({ count: this.get('commentsCount') });
   });
+
+  test('should be expanded if page is defined', async function (assert) {
+    assert.expect(1);
+
+    this.setProperties({
+      articleId: 10,
+      articleTitle: 'Foo',
+      articleNamespace: 0,
+      isUcp: true,
+    });
+
+    await render(hbs`<ArticleComments @isUcp={{this.isUcp}} @page="1" @articleId={{this.articleId}} @articleTitle={{this.articleTitle}} @articleNamespace={{this.articleNamespace}} />`);
+
+    assert.dom('#articleComments').exists();
+  });
+
+  test('should be hidden if page is not defined', async function (assert) {
+    assert.expect(1);
+
+    this.setProperties({
+      articleId: 10,
+      articleTitle: 'Foo',
+      articleNamespace: 0,
+      isUcp: true,
+    });
+
+    await render(hbs`<ArticleComments @isUcp={{this.isUcp}} @articleId={{this.articleId}} @articleTitle={{this.articleTitle}} @articleNamespace={{this.articleNamespace}} />`);
+
+    assert.dom('#articleComments').doesNotExist();
+  });
+
+  test('should be hidden if page is null', async function (assert) {
+    assert.expect(1);
+
+    this.setProperties({
+      articleId: 10,
+      articleTitle: 'Foo',
+      articleNamespace: 0,
+      isUcp: true,
+    });
+
+    await render(hbs`<ArticleComments @isUcp={{this.isUcp}} @page={{null}} @articleId={{this.articleId}} @articleTitle={{this.articleTitle}} @articleNamespace={{this.articleNamespace}} />`);
+
+    assert.dom('#articleComments').doesNotExist();
+  });
 });


### PR DESCRIPTION
## Links

https://wikia-inc.atlassian.net/browse/IW-4118

## Problem

Clicking on category link caused scrolling to bottom.

## Solution

There is a condition for article-comments component that checks if `page` variable is not `null` to scroll to article comments. But in case the `page` is `undefined` it was also scrolling because there was no condition for that.
