### PR TITLE
SER-4223 | Search: add 'gamepedia' query for Gamepedia

### DIFF
--- a/app/models/search.js
+++ b/app/models/search.js
@@ -81,6 +81,7 @@ export default EmberObject.extend({
       lang: this.wikiVariables.language.content,
       namespace: 0,
       limit: 25,
+      gamepedia: this.wikiVariables.enableHydraFeatures || false,
     };
 
     if (this.get('scope') === 'internal') {


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/SER-4223

## Description

For Gamepedia wikis add 'gamepedia=true' query param when calling unified-search. English Gamepedia wikis are stored in another index. 