### PR TITLE
Bump article-comments version to 0.9.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": ">= 10.*"
   },
   "dependencies": {
-    "@fandom/article-comments": "0.9.13",
+    "@fandom/article-comments": "0.9.14",
     "@fandom/web-editor": "1.4.1",
     "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v76.5.0",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/CAKE-5888

## Description
Bump article-comments version to 0.9.14 which was created for CAKE-5888 (see https://github.com/Wikia/unified-platform/pull/3123)

## Reviewers
@xkxd 