### PR TITLE
DE-4807 | add scriptPath to header store

### DIFF
--- a/app/components/fastboot-only/body-bottom.js
+++ b/app/components/fastboot-only/body-bottom.js
@@ -39,6 +39,7 @@ export default Component.extend({
       'qualarooUrl',
       'isTestWiki',
     );
+    wikiVariables.scriptPath = this.wikiVariables.articlePath.replace(/\/$/, '');
 
     return JSON.stringify(Object.assign({
       cookieDomain,

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "form-data": "3.0.0",
     "i18next": "17.3.1",
     "loader.js": "4.7.0",
-    "mercury-shared": "github:wikia/mercury-shared#e832a4e4bf3f23fd0876496e06bc9fa102bc43cd",
+    "mercury-shared": "github:wikia/mercury-shared#bebd738d244c071de8d72ebdd08d2c8f41b00d3e",
     "node-sass": "4.14.1",
     "proxying-agent": "2.4.0",
     "qunit-dom": "0.8.0",


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/DE-4807
* https://github.com/Wikia/mercury-shared/pull/16

## Description

Adds `scriptPath` (`/wiki` or `/wiki/{lang}`) to the header store, so that it's available for tracking implemented in `mercury-shared`.

## Reviewers

Use `@` mentions here. Alternatively, assign the pull request to a person.
