### PR TITLE
IW | Fix body-bottom script path

### DIFF
--- a/app/components/fastboot-only/body-bottom.js
+++ b/app/components/fastboot-only/body-bottom.js
@@ -38,8 +38,8 @@ export default Component.extend({
       'language',
       'qualarooUrl',
       'isTestWiki',
+      'scriptPath',
     );
-    wikiVariables.scriptPath = this.wikiVariables.articlePath.replace(/\/$/, '');
 
     return JSON.stringify(Object.assign({
       cookieDomain,


### PR DESCRIPTION
## Description
For the pv_tracking cookie, use the scriptPath from wikiVariables service instead of parsing articlePath.

## Reviewers
@Wikia/iwing 
@Wikia/data-engineering 
