### PR TITLE
Fix styling for collapsible menu

### DIFF
--- a/app/styles/component/_collapsible-menu-lazy.scss
+++ b/app/styles/component/_collapsible-menu-lazy.scss
@@ -1,6 +1,6 @@
 .collapsible-menu {
-  ol,
-  ul {
+  > ol,
+  > ul {
     display: block;
     list-style: none;
     margin: 12px 0 0;

--- a/app/styles/package.json
+++ b/app/styles/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fandom/mobile-wiki-styles",
   "description": "Mobile wiki styles package used by Mobile Visual Editor in UCP",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "publishConfig": {
     "registry": "https://artifactory.wikia-inc.com/artifactory/api/npm/wikia-npm/"
   }


### PR DESCRIPTION
During working on Fandom Mobile skin I noticed that inner `ul` and `ol` within collapsible menu are broken. This PR fixes it.