### PR TITLE
PLATFORM-5163: adding pv_unique_id to our performance metrics

### DIFF
--- a/app/utils/performance.js
+++ b/app/utils/performance.js
@@ -113,13 +113,8 @@ export default (baseUrl, softwareVersion, sampleFactor) => {
                 .join('&')}`;
         }
         // PLATFORM-5163: send pv_unique_id along with the performance metric
-        try {
-          const pvUID = mw.config.get('pvUID');
-          if (pvUID) {
-            url += `&pv=${pvUID}`;
-          }
-        } catch {
-          // send the metrics even if pvUID couldn't be fetched
+        if (window.pvUID) {
+          url += `&pv=${window.pvUID}`;
         }
         // Send the performance info
         if (navigator.sendBeacon) {

--- a/app/utils/performance.js
+++ b/app/utils/performance.js
@@ -112,7 +112,7 @@ export default (baseUrl, softwareVersion, sampleFactor) => {
                 .map(p => p.map(encodeURIComponent).join('='))
                 .join('&')}`;
         }
-        // PLATFORM-5163: send pv_unique_id along with the performance metric
+        // PLATFORM-5163: send pv_unique_id along with the performance metrics
         if (window.pvUID) {
           url += `&pv=${encodeURIComponent(window.pvUID)}`;
         }

--- a/app/utils/performance.js
+++ b/app/utils/performance.js
@@ -112,6 +112,15 @@ export default (baseUrl, softwareVersion, sampleFactor) => {
                 .map(p => p.map(encodeURIComponent).join('='))
                 .join('&')}`;
         }
+        // PLATFORM-5163: send pv_unique_id along with the performance metric
+        try {
+          const pvUID = mw.config.get('pvUID');
+          if (pvUID) {
+            url += `&pv=${pvUID}`;
+          }
+        } catch {
+          // send the metrics even if pvUID couldn't be fetched
+        }
         // Send the performance info
         if (navigator.sendBeacon) {
           navigator.sendBeacon(url);

--- a/app/utils/performance.js
+++ b/app/utils/performance.js
@@ -114,7 +114,7 @@ export default (baseUrl, softwareVersion, sampleFactor) => {
         }
         // PLATFORM-5163: send pv_unique_id along with the performance metric
         if (window.pvUID) {
-          url += `&pv=${window.pvUID}`;
+          url += '&pv=' + encodeURIComponent(window.pvUID);
         }
         // Send the performance info
         if (navigator.sendBeacon) {

--- a/app/utils/performance.js
+++ b/app/utils/performance.js
@@ -114,7 +114,7 @@ export default (baseUrl, softwareVersion, sampleFactor) => {
         }
         // PLATFORM-5163: send pv_unique_id along with the performance metric
         if (window.pvUID) {
-          url += '&pv=' + encodeURIComponent(window.pvUID);
+          url += `&pv=${encodeURIComponent(window.pvUID)}`;
         }
         // Send the performance info
         if (navigator.sendBeacon) {


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/PLATFORM-5163

## Description

Adding pv_unique_id per AdEng request. This is done in order to join events tracked to statsdb.performance_tracking data and analyze which specific ads correlate with weaker score