### PR TITLE
ADEN-10737 Update ad-engine (v80.5.0)

### DIFF
--- a/app/modules/ads/ad-context.js
+++ b/app/modules/ads/ad-context.js
@@ -556,9 +556,9 @@ export const defaultAdContext = {
       appId: 'P26086A07-C7FB-4124-A679-8AC404198BA7',
     },
     realVu: {
-			id: 'c=E6H4_f=mint',
-			enabled: false,
-		},
+      id: 'c=E6H4_f=mint',
+      enabled: false,
+    },
   },
   slotGroups: {
     VIDEO: ['ABCD', 'FEATURED', 'OUTSTREAM', 'UAP_BFAA', 'UAP_BFAB', 'VIDEO'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -3655,8 +3655,8 @@
       }
     },
     "@wikia/ad-engine": {
-      "version": "git+https://github.com/Wikia/ad-engine.git#533ac00eac95dba83789b66c3e4123f969cebc1b",
-      "from": "git+https://github.com/Wikia/ad-engine.git#533ac00eac95dba83789b66c3e4123f969cebc1b",
+      "version": "git+https://github.com/Wikia/ad-engine.git#5e13e638441f323121a646f773804f7195beb43b",
+      "from": "git+https://github.com/Wikia/ad-engine.git#v80.5.0",
       "requires": {
         "@babel/runtime-corejs2": "^7.3.1",
         "@iabtcf/stub": "1.1.3",
@@ -24983,9 +24983,9 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "query-string": {
-      "version": "6.13.7",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.7.tgz",
-      "integrity": "sha512-CsGs8ZYb39zu0WLkeOhe0NMePqgYdAuCqxOYKDR5LVCytDZYMGx3Bb+xypvQvPHVPijRXB0HZNFllCzHRe4gEA==",
+      "version": "6.13.8",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.8.tgz",
+      "integrity": "sha512-jxJzQI2edQPE/NPUOusNjO/ZOGqr1o2OBa/3M00fU76FsLXDVbJDv/p7ng5OdQyorKrkRz1oqfwmbe5MAMePQg==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "split-on-first": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@fandom/article-comments": "0.9.14",
     "@fandom/web-editor": "1.4.1",
-    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#533ac00eac95dba83789b66c3e4123f969cebc1b",
+    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v80.5.0",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",
     "@wikia/post-quecast": "2.0.1",
     "@wikia/search-tracking": "github:Wikia/search-tracking#2.0.0",


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/ADEN-10737

## Description

Enabling RealVu on mobile-wiki. This time with the proper ad-engine version.

## Reviewers

@dmnsobczak @KonradLinkowski 
