### PR TITLE
[DE recommendations] Don't send user beacon to recommendation service

### DIFF
--- a/app/components/recirculation-prefooter.js
+++ b/app/components/recirculation-prefooter.js
@@ -168,13 +168,8 @@ export default Component.extend(
     fetchRecommendedData() {
       const qs = `?wikiId=${this.wikiVariables.id}&articleId=${this.articleId}`;
       const url = this.fetch.getServiceUrl('recommendations', `/recommendations${qs}`);
-      const options = {
-        headers: {
-          'X-Beacon': window.beacon_id,
-        },
-      };
 
-      this.fetch.fetchAndParseResponse(url, options, RecommendedDataFetchError)
+      this.fetch.fetchAndParseResponse(url, {}, RecommendedDataFetchError)
         .then((response) => {
           let filteredItems = this.getNonBlacklistedRecommendedData(response);
 


### PR DESCRIPTION
## Description

The recommendations service doesn't use the user's beacon, so we can remove it from the request.
