### PR TITLE
ADEN-10799 Start using ad-tag-manager tags from inlined data instead of additional call to the service

### DIFF
--- a/app/modules/ads/core/stable-ads.js
+++ b/app/modules/ads/core/stable-ads.js
@@ -341,7 +341,7 @@ class StableAds {
     }
 
     const { bidders } = window.Wikia.adBidders;
-    const { context, slotService, taxonomyService } = window.Wikia.adEngine;
+    const { context, slotService, taxonomyService, utils } = window.Wikia.adEngine;
     const { permutive } = window.Wikia.adServices;
 
     permutive.call();
@@ -351,9 +351,14 @@ class StableAds {
     this.biddersInhibitor = null;
     bidders.requestBids().then(() => this.getBiddersInhibitor().resolve());
     inhibitors.push(this.getBiddersInhibitor());
-    if (context.get('wiki.targeting.isUcp')) {
+
+    if (!context.get('wiki.opts.enableAdTagManagerBackend')) {
+      utils.logger(logGroup, 'Taxonomy Service should be called from the frontend');
       inhibitors.push(taxonomyService.configurePageLevelTargeting());
+    } else {
+      utils.logger(logGroup, 'Taxonomy Service should have been called from the backend');
     }
+
     this.startAdEngine(inhibitors);
 
     if (!slotService.getState('top_leaderboard')) {

--- a/app/modules/ads/core/stable-ads.js
+++ b/app/modules/ads/core/stable-ads.js
@@ -345,7 +345,7 @@ class StableAds {
       context,
       slotService,
       taxonomyService,
-      utils
+      utils,
     } = window.Wikia.adEngine;
     const { permutive } = window.Wikia.adServices;
 

--- a/app/modules/ads/core/stable-ads.js
+++ b/app/modules/ads/core/stable-ads.js
@@ -341,7 +341,12 @@ class StableAds {
     }
 
     const { bidders } = window.Wikia.adBidders;
-    const { context, slotService, taxonomyService, utils } = window.Wikia.adEngine;
+    const {
+      context,
+      slotService,
+      taxonomyService,
+      utils
+    } = window.Wikia.adEngine;
     const { permutive } = window.Wikia.adServices;
 
     permutive.call();

--- a/app/modules/ads/targeting.js
+++ b/app/modules/ads/targeting.js
@@ -222,6 +222,7 @@ export const targeting = {
       ref: getRefParam(),
       esrb: adsContext.targeting.esrbRating,
       geo: window.Wikia.adEngine.utils.geoService.getCountryCode() || 'none',
+      adTagManagerTags: adsContext.targeting.adTagManagerTags || {},
     };
 
     if (window.pvNumber) {

--- a/app/modules/ads/targeting.js
+++ b/app/modules/ads/targeting.js
@@ -225,9 +225,15 @@ export const targeting = {
     };
 
     if ( adsContext.targeting.adTagManagerTags ) {
-      Object.keys(adsContext.targeting.adTagManagerTags).forEach((key) => {
-        pageLevelTargeting[key] = adsContext.targeting.adTagManagerTags[key];
-      });
+      // the adTagManagerTags.esrb is not valid with the schema we send to Permutive
+      // thus we can't just iterate through adTagManagerTags props
+      pageLevelTargeting.gnre = adsContext.targeting.adTagManagerTags.gnre || [];
+      pageLevelTargeting.media = adsContext.targeting.adTagManagerTags.media || [];
+      pageLevelTargeting.pform = adsContext.targeting.adTagManagerTags.pform || [];
+      pageLevelTargeting.pub = adsContext.targeting.adTagManagerTags.pub || [];
+      pageLevelTargeting.sex = adsContext.targeting.adTagManagerTags.sex || [];
+      pageLevelTargeting.theme = adsContext.targeting.adTagManagerTags.theme || [];
+      pageLevelTargeting.tv = adsContext.targeting.adTagManagerTags.tv || [];
     }
 
     if (window.pvNumber) {

--- a/app/modules/ads/targeting.js
+++ b/app/modules/ads/targeting.js
@@ -224,7 +224,7 @@ export const targeting = {
       geo: window.Wikia.adEngine.utils.geoService.getCountryCode() || 'none',
     };
 
-    if ( adsContext.targeting.adTagManagerTags ) {
+    if (adsContext.targeting.adTagManagerTags) {
       // the adTagManagerTags.esrb is not valid with the schema we send to Permutive
       // thus we can't just iterate through adTagManagerTags props
       pageLevelTargeting.gnre = adsContext.targeting.adTagManagerTags.gnre || [];

--- a/app/modules/ads/targeting.js
+++ b/app/modules/ads/targeting.js
@@ -225,6 +225,8 @@ export const targeting = {
       adTagManagerTags: adsContext.targeting.adTagManagerTags || {},
     };
 
+    console.log('=====', adsContext.targeting, adsContext.targeting.adTagManagerTags);
+
     if (window.pvNumber) {
       pageLevelTargeting.pv = window.pvNumber.toString();
     }

--- a/app/modules/ads/targeting.js
+++ b/app/modules/ads/targeting.js
@@ -222,8 +222,13 @@ export const targeting = {
       ref: getRefParam(),
       esrb: adsContext.targeting.esrbRating,
       geo: window.Wikia.adEngine.utils.geoService.getCountryCode() || 'none',
-      adTagManagerTags: adsContext.targeting.adTagManagerTags || {},
     };
+
+    if ( adsContext.targeting.adTagManagerTags ) {
+      Object.keys(adsContext.targeting.adTagManagerTags).forEach((key) => {
+        pageLevelTargeting[key] = adsContext.targeting.adTagManagerTags[key];
+      });
+    }
 
     if (window.pvNumber) {
       pageLevelTargeting.pv = window.pvNumber.toString();

--- a/app/modules/ads/targeting.js
+++ b/app/modules/ads/targeting.js
@@ -225,8 +225,6 @@ export const targeting = {
       adTagManagerTags: adsContext.targeting.adTagManagerTags || {},
     };
 
-    console.log('=====', adsContext.targeting, adsContext.targeting.adTagManagerTags);
-
     if (window.pvNumber) {
       pageLevelTargeting.pv = window.pvNumber.toString();
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4077,8 +4077,8 @@
       }
     },
     "@wikia/ad-engine": {
-      "version": "git+https://github.com/Wikia/ad-engine.git#62f083fa225774843b8541a2b2120cfac8604297",
-      "from": "git+https://github.com/Wikia/ad-engine.git#62f083fa225774843b8541a2b2120cfac8604297",
+      "version": "git+https://github.com/Wikia/ad-engine.git#60d888c8d57e9592b943abb80f314157181df405",
+      "from": "git+https://github.com/Wikia/ad-engine.git#60d888c8d57e9592b943abb80f314157181df405",
       "requires": {
         "@babel/runtime-corejs2": "^7.3.1",
         "@iabtcf/stub": "1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2434,9 +2434,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.13.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.13.9.tgz",
-      "integrity": "sha512-p6rtfkmJnAqFMVMgjtwhmfzj7S32BxdS2LtKKjCUNiOakFm8hro/vHwtVMEveYKjIsBPjoQiVMhelgs+FRDoLw==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.13.10.tgz",
+      "integrity": "sha512-rZw5P1ZewO6XZTDxtXuAuAFUqfNXyM8HO/9WiaDd34Anka0uFTpo0RvBLeV775AEE/zKw3LQB+poZw/O9lrZBg==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -4077,8 +4077,8 @@
       }
     },
     "@wikia/ad-engine": {
-      "version": "git+https://github.com/Wikia/ad-engine.git#60d888c8d57e9592b943abb80f314157181df405",
-      "from": "git+https://github.com/Wikia/ad-engine.git#60d888c8d57e9592b943abb80f314157181df405",
+      "version": "git+https://github.com/Wikia/ad-engine.git#b353f0c7b3a7ffeefc85b430aacee4297dfcfbaa",
+      "from": "git+https://github.com/Wikia/ad-engine.git#b353f0c7b3a7ffeefc85b430aacee4297dfcfbaa",
       "requires": {
         "@babel/runtime-corejs2": "^7.3.1",
         "@iabtcf/stub": "1.1.3",
@@ -9122,9 +9122,9 @@
           }
         },
         "@babel/compat-data": {
-          "version": "7.13.8",
-          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
-          "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog=="
+          "version": "7.13.11",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.11.tgz",
+          "integrity": "sha512-BwKEkO+2a67DcFeS3RLl0Z3Gs2OvdXewuWjc1Hfokhb5eQWP9YRYH1/+VrVZvql2CfjOiNGqSAFOYt4lsqTHzg=="
         },
         "@babel/generator": {
           "version": "7.13.9",
@@ -9137,9 +9137,9 @@
           }
         },
         "@babel/helper-compilation-targets": {
-          "version": "7.13.8",
-          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.8.tgz",
-          "integrity": "sha512-pBljUGC1y3xKLn1nrx2eAhurLMA8OqBtBP/JwG4U8skN7kf8/aqwwxpV1N6T0e7r6+7uNitIa/fUxPFagSXp3A==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
+          "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
           "requires": {
             "@babel/compat-data": "^7.13.8",
             "@babel/helper-validator-option": "^7.12.17",
@@ -9245,9 +9245,9 @@
           "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
         },
         "@babel/helpers": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.0.tgz",
-          "integrity": "sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
+          "integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
           "requires": {
             "@babel/template": "^7.12.13",
             "@babel/traverse": "^7.13.0",
@@ -9255,9 +9255,9 @@
           }
         },
         "@babel/highlight": {
-          "version": "7.13.8",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.8.tgz",
-          "integrity": "sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
             "chalk": "^2.0.0",
@@ -9265,9 +9265,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.9",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.9.tgz",
-          "integrity": "sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw=="
+          "version": "7.13.11",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.11.tgz",
+          "integrity": "sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q=="
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -9342,16 +9342,16 @@
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.13.8",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.8.tgz",
-              "integrity": "sha512-oYapIySGw1zGhEFRd6lzWNLWFX2s5dA/jm+Pw/+59ZdXtjyIuwlXbrId22Md0rgZVop+aVoqow2riXhBLNyuQg==",
+              "version": "7.13.10",
+              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
+              "integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
               "requires": {
                 "@babel/code-frame": "^7.12.13",
-                "@babel/generator": "^7.13.0",
-                "@babel/helper-compilation-targets": "^7.13.8",
+                "@babel/generator": "^7.13.9",
+                "@babel/helper-compilation-targets": "^7.13.10",
                 "@babel/helper-module-transforms": "^7.13.0",
-                "@babel/helpers": "^7.13.0",
-                "@babel/parser": "^7.13.4",
+                "@babel/helpers": "^7.13.10",
+                "@babel/parser": "^7.13.10",
                 "@babel/template": "^7.12.13",
                 "@babel/traverse": "^7.13.0",
                 "@babel/types": "^7.13.0",
@@ -9482,9 +9482,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001197",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001197.tgz",
-          "integrity": "sha512-8aE+sqBqtXz4G8g35Eg/XEaFr2N7rd/VQ6eABGBmNtcB8cN6qNJhMi6oSFy4UWWZgqgL3filHT8Nha4meu3tsw=="
+          "version": "1.0.30001200",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001200.tgz",
+          "integrity": "sha512-ic/jXfa6tgiPBAISWk16jRI2q8YfjxHnSG7ddSL1ptrIP8Uy11SayFrjXRAk3NumHpDb21fdTkbTxb/hOrFrnQ=="
         },
         "debug": {
           "version": "4.3.1",
@@ -9495,9 +9495,9 @@
           }
         },
         "electron-to-chromium": {
-          "version": "1.3.682",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.682.tgz",
-          "integrity": "sha512-zok2y37qR00U14uM6qBz/3iIjWHom2eRfC2S1StA0RslP7x34jX+j4mxv80t8OEOHLJPVG54ZPeaFxEI7gPrwg=="
+          "version": "1.3.687",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
+          "integrity": "sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ=="
         },
         "ember-cli-babel": {
           "version": "7.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4077,8 +4077,8 @@
       }
     },
     "@wikia/ad-engine": {
-      "version": "git+https://github.com/Wikia/ad-engine.git#dda7a5d69bfab7f195b7dbc186bf705cd83a4409",
-      "from": "git+https://github.com/Wikia/ad-engine.git#dda7a5d69bfab7f195b7dbc186bf705cd83a4409",
+      "version": "git+https://github.com/Wikia/ad-engine.git#7ec45aec350c7fce8a6ec168861ca32445a4d94d",
+      "from": "git+https://github.com/Wikia/ad-engine.git#v81.10.1",
       "requires": {
         "@babel/runtime-corejs2": "^7.3.1",
         "@iabtcf/stub": "1.1.3",
@@ -9482,9 +9482,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001202",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001202.tgz",
-          "integrity": "sha512-ZcijQNqrcF8JNLjzvEiXqX4JUYxoZa7Pvcsd9UD8Kz4TvhTonOSNRsK+qtvpVL4l6+T1Rh4LFtLfnNWg6BGWCQ=="
+          "version": "1.0.30001203",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001203.tgz",
+          "integrity": "sha512-/I9tvnzU/PHMH7wBPrfDMSuecDeUKerjCPX7D0xBbaJZPxoT9m+yYxt0zCTkcijCkjTdim3H56Zm0i5Adxch4w=="
         },
         "debug": {
           "version": "4.3.1",
@@ -9495,9 +9495,9 @@
           }
         },
         "electron-to-chromium": {
-          "version": "1.3.690",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.690.tgz",
-          "integrity": "sha512-zPbaSv1c8LUKqQ+scNxJKv01RYFkVVF1xli+b+3Ty8ONujHjAMg+t/COmdZqrtnS1gT+g4hbSodHillymt1Lww=="
+          "version": "1.3.692",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.692.tgz",
+          "integrity": "sha512-Ix+zDUAXWZuUzqKdhkgN5dP7ZM+IwMG4yAGFGDLpGJP/3vNEEwuHG1LIhtXUfW0FFV0j38t5PUv2n/3MFSRviQ=="
         },
         "ember-cli-babel": {
           "version": "7.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4077,8 +4077,8 @@
       }
     },
     "@wikia/ad-engine": {
-      "version": "git+https://github.com/Wikia/ad-engine.git#6c575df99b15ccff9da7c2d725aadd648b9a1fb8",
-      "from": "git+https://github.com/Wikia/ad-engine.git#6c575df99b15ccff9da7c2d725aadd648b9a1fb8",
+      "version": "git+https://github.com/Wikia/ad-engine.git#62f083fa225774843b8541a2b2120cfac8604297",
+      "from": "git+https://github.com/Wikia/ad-engine.git#62f083fa225774843b8541a2b2120cfac8604297",
       "requires": {
         "@babel/runtime-corejs2": "^7.3.1",
         "@iabtcf/stub": "1.1.3",
@@ -9482,9 +9482,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001196",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001196.tgz",
-          "integrity": "sha512-CPvObjD3ovWrNBaXlAIGWmg2gQQuJ5YhuciUOjPRox6hIQttu8O+b51dx6VIpIY9ESd2d0Vac1RKpICdG4rGUg=="
+          "version": "1.0.30001197",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001197.tgz",
+          "integrity": "sha512-8aE+sqBqtXz4G8g35Eg/XEaFr2N7rd/VQ6eABGBmNtcB8cN6qNJhMi6oSFy4UWWZgqgL3filHT8Nha4meu3tsw=="
         },
         "debug": {
           "version": "4.3.1",
@@ -9495,9 +9495,9 @@
           }
         },
         "electron-to-chromium": {
-          "version": "1.3.681",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.681.tgz",
-          "integrity": "sha512-W6uYvSUTHuyX2DZklIESAqx57jfmGjUkd7Z3RWqLdj9Mmt39ylhBuvFXlskQnvBHj0MYXIeQI+mjiwVddZLSvA=="
+          "version": "1.3.682",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.682.tgz",
+          "integrity": "sha512-zok2y37qR00U14uM6qBz/3iIjWHom2eRfC2S1StA0RslP7x34jX+j4mxv80t8OEOHLJPVG54ZPeaFxEI7gPrwg=="
         },
         "ember-cli-babel": {
           "version": "7.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4077,8 +4077,8 @@
       }
     },
     "@wikia/ad-engine": {
-      "version": "git+https://github.com/Wikia/ad-engine.git#902480ea071e31be43d4ff25e37427fee62afbce",
-      "from": "git+https://github.com/Wikia/ad-engine.git#902480ea071e31be43d4ff25e37427fee62afbce",
+      "version": "git+https://github.com/Wikia/ad-engine.git#dda7a5d69bfab7f195b7dbc186bf705cd83a4409",
+      "from": "git+https://github.com/Wikia/ad-engine.git#dda7a5d69bfab7f195b7dbc186bf705cd83a4409",
       "requires": {
         "@babel/runtime-corejs2": "^7.3.1",
         "@iabtcf/stub": "1.1.3",
@@ -9482,9 +9482,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001200",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001200.tgz",
-          "integrity": "sha512-ic/jXfa6tgiPBAISWk16jRI2q8YfjxHnSG7ddSL1ptrIP8Uy11SayFrjXRAk3NumHpDb21fdTkbTxb/hOrFrnQ=="
+          "version": "1.0.30001202",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001202.tgz",
+          "integrity": "sha512-ZcijQNqrcF8JNLjzvEiXqX4JUYxoZa7Pvcsd9UD8Kz4TvhTonOSNRsK+qtvpVL4l6+T1Rh4LFtLfnNWg6BGWCQ=="
         },
         "debug": {
           "version": "4.3.1",
@@ -9495,9 +9495,9 @@
           }
         },
         "electron-to-chromium": {
-          "version": "1.3.688",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.688.tgz",
-          "integrity": "sha512-tbKinYX7BomVBcWHzwGolzv3kqCdk/vQ36ao3MC8tQMXqs1ZpevYU2RTr7+hkDvGWtoQbe+nvvl+GfMFmRna/A=="
+          "version": "1.3.690",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.690.tgz",
+          "integrity": "sha512-zPbaSv1c8LUKqQ+scNxJKv01RYFkVVF1xli+b+3Ty8ONujHjAMg+t/COmdZqrtnS1gT+g4hbSodHillymt1Lww=="
         },
         "ember-cli-babel": {
           "version": "7.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4077,8 +4077,8 @@
       }
     },
     "@wikia/ad-engine": {
-      "version": "git+https://github.com/Wikia/ad-engine.git#0ceb684501532c528cec73d915ec9b118282d9ac",
-      "from": "git+https://github.com/Wikia/ad-engine.git#v81.8.0",
+      "version": "git+https://github.com/Wikia/ad-engine.git#6c575df99b15ccff9da7c2d725aadd648b9a1fb8",
+      "from": "git+https://github.com/Wikia/ad-engine.git#6c575df99b15ccff9da7c2d725aadd648b9a1fb8",
       "requires": {
         "@babel/runtime-corejs2": "^7.3.1",
         "@iabtcf/stub": "1.1.3",
@@ -9495,9 +9495,9 @@
           }
         },
         "electron-to-chromium": {
-          "version": "1.3.680",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.680.tgz",
-          "integrity": "sha512-XBACJT9RdpdWtoMXQPR8Be3ZtmizWWbxfw8cY2b5feUwiDO3FUl8qo4W2jXoq/WnnA3xBRqafu1XbpczqyUvlA=="
+          "version": "1.3.681",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.681.tgz",
+          "integrity": "sha512-W6uYvSUTHuyX2DZklIESAqx57jfmGjUkd7Z3RWqLdj9Mmt39ylhBuvFXlskQnvBHj0MYXIeQI+mjiwVddZLSvA=="
         },
         "ember-cli-babel": {
           "version": "7.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4077,8 +4077,8 @@
       }
     },
     "@wikia/ad-engine": {
-      "version": "git+https://github.com/Wikia/ad-engine.git#b353f0c7b3a7ffeefc85b430aacee4297dfcfbaa",
-      "from": "git+https://github.com/Wikia/ad-engine.git#b353f0c7b3a7ffeefc85b430aacee4297dfcfbaa",
+      "version": "git+https://github.com/Wikia/ad-engine.git#902480ea071e31be43d4ff25e37427fee62afbce",
+      "from": "git+https://github.com/Wikia/ad-engine.git#902480ea071e31be43d4ff25e37427fee62afbce",
       "requires": {
         "@babel/runtime-corejs2": "^7.3.1",
         "@iabtcf/stub": "1.1.3",
@@ -9495,9 +9495,9 @@
           }
         },
         "electron-to-chromium": {
-          "version": "1.3.687",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
-          "integrity": "sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ=="
+          "version": "1.3.688",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.688.tgz",
+          "integrity": "sha512-tbKinYX7BomVBcWHzwGolzv3kqCdk/vQ36ao3MC8tQMXqs1ZpevYU2RTr7+hkDvGWtoQbe+nvvl+GfMFmRna/A=="
         },
         "ember-cli-babel": {
           "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@fandom/article-comments": "0.9.14",
     "@fandom/design-system": "23.24.0",
     "@fandom/web-editor": "1.4.1",
-    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#dda7a5d69bfab7f195b7dbc186bf705cd83a4409",
+    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v81.10.1",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",
     "@wikia/post-quecast": "2.0.1",
     "@wikia/search-tracking": "github:Wikia/search-tracking#2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@fandom/article-comments": "0.9.14",
     "@fandom/design-system": "23.24.0",
     "@fandom/web-editor": "1.4.1",
-    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#62f083fa225774843b8541a2b2120cfac8604297",
+    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#60d888c8d57e9592b943abb80f314157181df405",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",
     "@wikia/post-quecast": "2.0.1",
     "@wikia/search-tracking": "github:Wikia/search-tracking#2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@fandom/article-comments": "0.9.14",
     "@fandom/design-system": "23.24.0",
     "@fandom/web-editor": "1.4.1",
-    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#v81.8.0",
+    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#6c575df99b15ccff9da7c2d725aadd648b9a1fb8",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",
     "@wikia/post-quecast": "2.0.1",
     "@wikia/search-tracking": "github:Wikia/search-tracking#2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@fandom/article-comments": "0.9.14",
     "@fandom/design-system": "23.24.0",
     "@fandom/web-editor": "1.4.1",
-    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#6c575df99b15ccff9da7c2d725aadd648b9a1fb8",
+    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#62f083fa225774843b8541a2b2120cfac8604297",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",
     "@wikia/post-quecast": "2.0.1",
     "@wikia/search-tracking": "github:Wikia/search-tracking#2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@fandom/article-comments": "0.9.14",
     "@fandom/design-system": "23.24.0",
     "@fandom/web-editor": "1.4.1",
-    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#b353f0c7b3a7ffeefc85b430aacee4297dfcfbaa",
+    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#902480ea071e31be43d4ff25e37427fee62afbce",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",
     "@wikia/post-quecast": "2.0.1",
     "@wikia/search-tracking": "github:Wikia/search-tracking#2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@fandom/article-comments": "0.9.14",
     "@fandom/design-system": "23.24.0",
     "@fandom/web-editor": "1.4.1",
-    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#902480ea071e31be43d4ff25e37427fee62afbce",
+    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#dda7a5d69bfab7f195b7dbc186bf705cd83a4409",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",
     "@wikia/post-quecast": "2.0.1",
     "@wikia/search-tracking": "github:Wikia/search-tracking#2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@fandom/article-comments": "0.9.14",
     "@fandom/design-system": "23.24.0",
     "@fandom/web-editor": "1.4.1",
-    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#60d888c8d57e9592b943abb80f314157181df405",
+    "@wikia/ad-engine": "git+https://github.com/Wikia/ad-engine.git#b353f0c7b3a7ffeefc85b430aacee4297dfcfbaa",
     "@wikia/ember-fandom": "github:Wikia/ember-fandom#d12e79e46c33c889560b2b4b26af034c8c21b2c9",
     "@wikia/post-quecast": "2.0.1",
     "@wikia/search-tracking": "github:Wikia/search-tracking#2.0.0",


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/ADEN-10799
* https://github.com/Wikia/ad-engine/pull/981
* https://github.com/Wikia/unified-platform/pull/4860

## Description
Bump ad-engine and start using ad-tag-manager inlined data.
