### PR TITLE
SITE-670 | set CPU limits in k8s descriptors

### DIFF
--- a/fastboot-server/app/server.js
+++ b/fastboot-server/app/server.js
@@ -13,7 +13,7 @@ const server = new FastBootAppServer({
   afterMiddleware: middlewares.after,
   distPath: config.distPath,
   gzip: true,
-  workerCount: 16,
+  workerCount: 1,
 });
 
 server.start();

--- a/fastboot-server/app/server.js
+++ b/fastboot-server/app/server.js
@@ -13,7 +13,7 @@ const server = new FastBootAppServer({
   afterMiddleware: middlewares.after,
   distPath: config.distPath,
   gzip: true,
-  workerCount: 1,
+  workerCount: 8,
 });
 
 server.start();

--- a/fastboot-server/app/server.js
+++ b/fastboot-server/app/server.js
@@ -13,7 +13,7 @@ const server = new FastBootAppServer({
   afterMiddleware: middlewares.after,
   distPath: config.distPath,
   gzip: true,
-  workerCount: 8,
+  workerCount: 16,
 });
 
 server.start();

--- a/k8s/k8s-deployment-descriptor-template-prod.yaml
+++ b/k8s/k8s-deployment-descriptor-template-prod.yaml
@@ -70,6 +70,7 @@ spec:
             cpu: 1.0
             memory: 1.5Gi
           limits:
+            cpu: 4.0
             memory: 2.5Gi
         ports:
         - containerPort: 8001

--- a/k8s/k8s-deployment-descriptor-template.yaml
+++ b/k8s/k8s-deployment-descriptor-template.yaml
@@ -73,6 +73,7 @@ spec:
               cpu: 0.4
               memory: 1Gi
             limits:
+              cpu: 3.0
               memory: 2Gi
           ports:
             - containerPort: 8007

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     ]
   },
   "fastbootDependencies": [
+    "abortcontroller-polyfill",
     "bunyan",
     "crypto",
     "deep-extend",


### PR DESCRIPTION
## Links
* http://wikia-inc.atlassian.net/browse/SITE-670

## Description
Similar issue as in this RCA: https://wikia-inc.atlassian.net/wiki/spaces/SE/pages/1734443093/Increased+5xx+error+rate+in+discussion+service

For some reason, default 1.0 CPU limit started to be respected, therefore pods were throttled and that caused failures

## Reviewers
@Wikia/site-experience 
