### PR TITLE
Fix tracking session

### DIFF
--- a/vendor/inline-scripts/pageview-tracking-experiment.js
+++ b/vendor/inline-scripts/pageview-tracking-experiment.js
@@ -60,10 +60,9 @@
   function setCookies() {
     if (!getCookieValue('tracking_session_id')) {
       const expireDate = new Date(Date.now() + 1000 * 60 * 30);
-      const scriptPath = headData.wikiVariables.scriptPath || '/';
 
       document.cookie = 'tracking_session_id=' + sessionId + '; expires=' + expireDate.toGMTString() +
-        ';domain=' + headData.cookieDomain + '; path=' + scriptPath  + ';';
+        ';domain=' + headData.cookieDomain + '; path=/;';
     }
   }
 


### PR DESCRIPTION
Fix setting session_id - path should always be / as we want to have same session id for all wikis