### PR TITLE
Scale down to 2 replicas

### DIFF
--- a/k8s/k8s-deployment-descriptor-template-prod.yaml
+++ b/k8s/k8s-deployment-descriptor-template-prod.yaml
@@ -12,7 +12,7 @@ metadata:
     status: active
     team: iwing
 spec:
-  replicas: 16
+  replicas: 2
   selector:
     matchLabels:
       app: mobile-wiki


### PR DESCRIPTION
As we moved most of the traffic from mobile-wiki to UCP, let's scale mobile-wiki down to 2 replicas.